### PR TITLE
add support for appending to files

### DIFF
--- a/packetnetworking/distros/debian/bonded.py
+++ b/packetnetworking/distros/debian/bonded.py
@@ -69,11 +69,12 @@ class DebianBondedNetwork(NetworkBuilder):
             {% endif %}
         """
 
-        self.tasks[
-            "etc/modules"
-        ] = """\
+        self.tasks["etc/modules"] = {
+            "file_mode": "a",
+            "template": """\
             bonding
-        """
+        """,
+        }
 
         self.tasks[
             "etc/resolv.conf"

--- a/packetnetworking/distros/debian/test_debian_10_bonded.py
+++ b/packetnetworking/distros/debian/test_debian_10_bonded.py
@@ -195,7 +195,8 @@ def test_debian_10_task_etc_modules(debian_10_bonded_network):
         bonding
     """
     )
-    assert tasks["etc/modules"] == result
+    assert tasks["etc/modules"]["file_mode"] == "a"
+    assert tasks["etc/modules"]["content"] == result
 
 
 def test_debian_10_etc_resolvers_configured(debian_10_bonded_network, fake):

--- a/packetnetworking/distros/debian/test_debian_7_bonded.py
+++ b/packetnetworking/distros/debian/test_debian_7_bonded.py
@@ -195,7 +195,8 @@ def test_debian_7_task_etc_modules(debian_7_bonded_network):
         bonding
     """
     )
-    assert tasks["etc/modules"] == result
+    assert tasks["etc/modules"]["file_mode"] == "a"
+    assert tasks["etc/modules"]["content"] == result
 
 
 def test_debian_7_etc_resolvers_configured(debian_7_bonded_network, fake):

--- a/packetnetworking/distros/debian/test_debian_8_bonded.py
+++ b/packetnetworking/distros/debian/test_debian_8_bonded.py
@@ -195,7 +195,8 @@ def test_debian_8_task_etc_modules(debian_8_bonded_network):
         bonding
     """
     )
-    assert tasks["etc/modules"] == result
+    assert tasks["etc/modules"]["file_mode"] == "a"
+    assert tasks["etc/modules"]["content"] == result
 
 
 def test_debian_8_etc_resolvers_configured(debian_8_bonded_network, fake):

--- a/packetnetworking/distros/debian/test_debian_9_bonded.py
+++ b/packetnetworking/distros/debian/test_debian_9_bonded.py
@@ -195,7 +195,8 @@ def test_debian_9_task_etc_modules(debian_9_bonded_network):
         bonding
     """
     )
-    assert tasks["etc/modules"] == result
+    assert tasks["etc/modules"]["file_mode"] == "a"
+    assert tasks["etc/modules"]["content"] == result
 
 
 def test_debian_9_etc_resolvers_configured(debian_9_bonded_network, fake):

--- a/packetnetworking/distros/debian/test_ubuntu_1404_bonded.py
+++ b/packetnetworking/distros/debian/test_ubuntu_1404_bonded.py
@@ -239,7 +239,8 @@ def test_ubuntu_1404_task_etc_modules(ubuntu_1404_bonded_network):
         bonding
     """
     )
-    assert tasks["etc/modules"] == result
+    assert tasks["etc/modules"]["file_mode"] == "a"
+    assert tasks["etc/modules"]["content"] == result
 
 
 def test_ubuntu_1404_etc_resolvers_configured(ubuntu_1404_bonded_network, fake):

--- a/packetnetworking/distros/debian/test_ubuntu_1604_bonded.py
+++ b/packetnetworking/distros/debian/test_ubuntu_1604_bonded.py
@@ -239,7 +239,8 @@ def test_ubuntu_1604_task_etc_modules(ubuntu_1604_bonded_network):
         bonding
     """
     )
-    assert tasks["etc/modules"] == result
+    assert tasks["etc/modules"]["file_mode"] == "a"
+    assert tasks["etc/modules"]["content"] == result
 
 
 def test_ubuntu_1604_etc_resolvers_configured(ubuntu_1604_bonded_network, fake):

--- a/packetnetworking/distros/debian/test_ubuntu_1804_bonded.py
+++ b/packetnetworking/distros/debian/test_ubuntu_1804_bonded.py
@@ -239,7 +239,8 @@ def test_ubuntu_1804_task_etc_modules(ubuntu_1804_bonded_network):
         bonding
     """
     )
-    assert tasks["etc/modules"] == result
+    assert tasks["etc/modules"]["file_mode"] == "a"
+    assert tasks["etc/modules"]["content"] == result
 
 
 def test_ubuntu_1804_etc_resolvers_configured(ubuntu_1804_bonded_network, fake):

--- a/packetnetworking/distros/debian/test_ubuntu_1904_bonded.py
+++ b/packetnetworking/distros/debian/test_ubuntu_1904_bonded.py
@@ -239,7 +239,8 @@ def test_ubuntu_1904_task_etc_modules(ubuntu_1904_bonded_network):
         bonding
     """
     )
-    assert tasks["etc/modules"] == result
+    assert tasks["etc/modules"]["file_mode"] == "a"
+    assert tasks["etc/modules"]["content"] == result
 
 
 def test_ubuntu_1904_etc_resolvers_configured(ubuntu_1904_bonded_network, fake):

--- a/packetnetworking/distros/network_builder.py
+++ b/packetnetworking/distros/network_builder.py
@@ -50,8 +50,10 @@ class NetworkBuilder:
                 rendered_tasks[path] = template
                 continue
 
+            file_mode = None
             mode = None
             if isinstance(template, dict):
+                file_mode = template.get("file_mode")
                 mode = template.get("mode", None)
                 template = template.get("template")
 
@@ -62,13 +64,14 @@ class NetworkBuilder:
                 trim_blocks=True,
                 undefined=StrictUndefined,
             )
-            if mode is None:
-                rendered_tasks[path] = template.render(self.context())
-            else:
+            if file_mode or mode:
                 rendered_tasks[path] = {
+                    "file_mode": file_mode,
                     "mode": mode,
                     "content": template.render(self.context()),
                 }
+            else:
+                rendered_tasks[path] = template.render(self.context())
         return rendered_tasks
 
     def run(self, rootfs_path):
@@ -86,8 +89,10 @@ class NetworkBuilder:
                     )
                 continue
 
+            file_mode = "w"
             mode = None
             if isinstance(content, dict):
+                file_mode = content.get("file_mode") or file_mode
                 mode = content.get("mode", None)
                 content = content.get("content")
 
@@ -97,7 +102,7 @@ class NetworkBuilder:
                 os.makedirs(name_dir, exist_ok=True)
 
             log.debug("Writing content to '{}'".format(abspath))
-            with open(abspath, "w") as f:
+            with open(abspath, file_mode) as f:
                 f.write(content)
 
             if mode:


### PR DESCRIPTION
Some customers with customer images have some custom files. One file
in particular we've seen is `/etc/modules`. So instead of overwriting
the file, we would like to append to the file.

This change allows us to add a `file_mode` option to tasks, modifying
the `mode` attribute in `open()`. By default `w` is used, however it
can be set to `a` to append to the file.