### PR TITLE
remove udev kernel flag

### DIFF
--- a/packetnetworking/distros/debian/test_ubuntu_1404_bonded.py
+++ b/packetnetworking/distros/debian/test_ubuntu_1404_bonded.py
@@ -310,10 +310,10 @@ def test_ubuntu_1404_persistent_interface_names(ubuntu_1404_bonded_network):
         # line, and change only the value of the NAME= key.
 
         # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface0.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", KERNEL=="e*", NAME="{iface0.name}"
+        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface0.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", NAME="{iface0.name}"
 
         # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface1.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", KERNEL=="e*", NAME="{iface1.name}"
+        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface1.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", NAME="{iface1.name}"
     """
     ).format(iface0=builder.network.interfaces[0], iface1=builder.network.interfaces[1])
     assert tasks["etc/udev/rules.d/70-persistent-net.rules"] == result

--- a/packetnetworking/distros/debian/test_ubuntu_1404_individual.py
+++ b/packetnetworking/distros/debian/test_ubuntu_1404_individual.py
@@ -225,10 +225,10 @@ def test_ubuntu_1404_persistent_interface_names(ubuntu_1404_individual_network):
         # line, and change only the value of the NAME= key.
 
         # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface0.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", KERNEL=="e*", NAME="{iface0.name}"
+        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface0.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", NAME="{iface0.name}"
 
         # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface1.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", KERNEL=="e*", NAME="{iface1.name}"
+        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface1.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", NAME="{iface1.name}"
     """
     ).format(iface0=builder.network.interfaces[0], iface1=builder.network.interfaces[1])
     assert tasks["etc/udev/rules.d/70-persistent-net.rules"] == result

--- a/packetnetworking/distros/debian/test_ubuntu_1904_bonded.py
+++ b/packetnetworking/distros/debian/test_ubuntu_1904_bonded.py
@@ -310,10 +310,10 @@ def test_ubuntu_1904_persistent_interface_names(ubuntu_1904_bonded_network):
         # line, and change only the value of the NAME= key.
 
         # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface0.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", KERNEL=="e*", NAME="{iface0.name}"
+        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface0.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", NAME="{iface0.name}"
 
         # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface1.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", KERNEL=="e*", NAME="{iface1.name}"
+        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface1.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", NAME="{iface1.name}"
     """
     ).format(iface0=builder.network.interfaces[0], iface1=builder.network.interfaces[1])
     assert tasks["etc/udev/rules.d/70-persistent-net.rules"] == result

--- a/packetnetworking/distros/debian/test_ubuntu_1904_individual.py
+++ b/packetnetworking/distros/debian/test_ubuntu_1904_individual.py
@@ -225,10 +225,10 @@ def test_ubuntu_1904_persistent_interface_names(ubuntu_1904_individual_network):
         # line, and change only the value of the NAME= key.
 
         # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface0.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", KERNEL=="e*", NAME="{iface0.name}"
+        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface0.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", NAME="{iface0.name}"
 
         # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface1.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", KERNEL=="e*", NAME="{iface1.name}"
+        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface1.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", NAME="{iface1.name}"
     """
     ).format(iface0=builder.network.interfaces[0], iface1=builder.network.interfaces[1])
     assert tasks["etc/udev/rules.d/70-persistent-net.rules"] == result

--- a/packetnetworking/distros/debian/test_ubuntu_1910_bonded.py
+++ b/packetnetworking/distros/debian/test_ubuntu_1910_bonded.py
@@ -310,10 +310,10 @@ def test_ubuntu_1910_persistent_interface_names(ubuntu_1910_bonded_network):
         # line, and change only the value of the NAME= key.
 
         # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface0.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", KERNEL=="e*", NAME="{iface0.name}"
+        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface0.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", NAME="{iface0.name}"
 
         # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface1.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", KERNEL=="e*", NAME="{iface1.name}"
+        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface1.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", NAME="{iface1.name}"
     """
     ).format(iface0=builder.network.interfaces[0], iface1=builder.network.interfaces[1])
     assert tasks["etc/udev/rules.d/70-persistent-net.rules"] == result

--- a/packetnetworking/distros/debian/test_ubuntu_1910_individual.py
+++ b/packetnetworking/distros/debian/test_ubuntu_1910_individual.py
@@ -225,10 +225,10 @@ def test_ubuntu_1910_persistent_interface_names(ubuntu_1910_individual_network):
         # line, and change only the value of the NAME= key.
 
         # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface0.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", KERNEL=="e*", NAME="{iface0.name}"
+        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface0.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", NAME="{iface0.name}"
 
         # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface1.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", KERNEL=="e*", NAME="{iface1.name}"
+        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface1.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", NAME="{iface1.name}"
     """
     ).format(iface0=builder.network.interfaces[0], iface1=builder.network.interfaces[1])
     assert tasks["etc/udev/rules.d/70-persistent-net.rules"] == result

--- a/packetnetworking/distros/redhat/test_rhel_7_bonded.py
+++ b/packetnetworking/distros/redhat/test_rhel_7_bonded.py
@@ -341,10 +341,10 @@ def test_rhel_7_persistent_interface_names(rhel_7_bonded_network):
         # line, and change only the value of the NAME= key.
 
         # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface0.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", KERNEL=="e*", NAME="{iface0.name}"
+        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface0.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", NAME="{iface0.name}"
 
         # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface1.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", KERNEL=="e*", NAME="{iface1.name}"
+        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface1.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", NAME="{iface1.name}"
     """
     ).format(iface0=builder.network.interfaces[0], iface1=builder.network.interfaces[1])
     assert tasks["etc/udev/rules.d/70-persistent-net.rules"] == result

--- a/packetnetworking/distros/redhat/test_rhel_7_individual.py
+++ b/packetnetworking/distros/redhat/test_rhel_7_individual.py
@@ -266,10 +266,10 @@ def test_rhel_7_persistent_interface_names(rhel_7_individual_network):
         # line, and change only the value of the NAME= key.
 
         # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface0.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", KERNEL=="e*", NAME="{iface0.name}"
+        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface0.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", NAME="{iface0.name}"
 
         # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface1.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", KERNEL=="e*", NAME="{iface1.name}"
+        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface1.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", NAME="{iface1.name}"
     """
     ).format(iface0=builder.network.interfaces[0], iface1=builder.network.interfaces[1])
     assert tasks["etc/udev/rules.d/70-persistent-net.rules"] == result

--- a/packetnetworking/distros/redhat/test_rhel_8_bonded.py
+++ b/packetnetworking/distros/redhat/test_rhel_8_bonded.py
@@ -341,10 +341,10 @@ def test_rhel_8_persistent_interface_names(rhel_8_bonded_network):
         # line, and change only the value of the NAME= key.
 
         # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface0.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", KERNEL=="e*", NAME="{iface0.name}"
+        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface0.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", NAME="{iface0.name}"
 
         # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface1.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", KERNEL=="e*", NAME="{iface1.name}"
+        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface1.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", NAME="{iface1.name}"
     """
     ).format(iface0=builder.network.interfaces[0], iface1=builder.network.interfaces[1])
     assert tasks["etc/udev/rules.d/70-persistent-net.rules"] == result

--- a/packetnetworking/distros/redhat/test_rhel_8_individual.py
+++ b/packetnetworking/distros/redhat/test_rhel_8_individual.py
@@ -264,10 +264,10 @@ def test_rhel_8_persistent_interface_names(rhel_8_individual_network):
         # line, and change only the value of the NAME= key.
 
         # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface0.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", KERNEL=="e*", NAME="{iface0.name}"
+        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface0.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", NAME="{iface0.name}"
 
         # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface1.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", KERNEL=="e*", NAME="{iface1.name}"
+        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface1.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", NAME="{iface1.name}"
     """
     ).format(iface0=builder.network.interfaces[0], iface1=builder.network.interfaces[1])
     assert tasks["etc/udev/rules.d/70-persistent-net.rules"] == result

--- a/packetnetworking/distros/redhat/test_scientific_7_bonded.py
+++ b/packetnetworking/distros/redhat/test_scientific_7_bonded.py
@@ -349,10 +349,10 @@ def test_scientific_7_persistent_interface_names(scientific_7_bonded_network):
         # line, and change only the value of the NAME= key.
 
         # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface0.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", KERNEL=="e*", NAME="{iface0.name}"
+        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface0.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", NAME="{iface0.name}"
 
         # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface1.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", KERNEL=="e*", NAME="{iface1.name}"
+        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface1.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", NAME="{iface1.name}"
     """
     ).format(iface0=builder.network.interfaces[0], iface1=builder.network.interfaces[1])
     assert tasks["etc/udev/rules.d/70-persistent-net.rules"] == result

--- a/packetnetworking/distros/redhat/test_scientific_7_individual.py
+++ b/packetnetworking/distros/redhat/test_scientific_7_individual.py
@@ -266,10 +266,10 @@ def test_scientific_7_persistent_interface_names(scientific_7_individual_network
         # line, and change only the value of the NAME= key.
 
         # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface0.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", KERNEL=="e*", NAME="{iface0.name}"
+        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface0.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", NAME="{iface0.name}"
 
         # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface1.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", KERNEL=="e*", NAME="{iface1.name}"
+        SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{{address}}=="{iface1.mac}", ATTR{{dev_id}}=="0x0", ATTR{{type}}=="1", NAME="{iface1.name}"
     """
     ).format(iface0=builder.network.interfaces[0], iface1=builder.network.interfaces[1])
     assert tasks["etc/udev/rules.d/70-persistent-net.rules"] == result

--- a/packetnetworking/utils.py
+++ b/packetnetworking/utils.py
@@ -174,7 +174,7 @@ def generate_persistent_names():
     {% for iface in interfaces %}
 
     # PCI device (custom name provided by external tool to mimic Predictable Network Interface Names)
-    SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="{{iface.mac}}", ATTR{dev_id}=="0x0", ATTR{type}=="1", KERNEL=="e*", NAME="{{iface.name}}"
+    SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="{{iface.mac}}", ATTR{dev_id}=="0x0", ATTR{type}=="1", NAME="{{iface.name}}"
     {% endfor %}
     """  # noqa
     return {"etc/udev/rules.d/70-persistent-net.rules": persistent_udev}


### PR DESCRIPTION
KERNEL=="e*", wasn't matching all the possible network interface names, like p1p1/p1p2 for example.