### PR TITLE
Add additional debugging

### DIFF
--- a/packetnetworking/builder.py
+++ b/packetnetworking/builder.py
@@ -66,6 +66,9 @@ class Builder(object):
         builder.build()
         return builder.run(rootfs_path)
 
+    def as_dict(self):
+        return {"metadata": self.metadata, "network": self.network.as_dict()}
+
 
 class NetworkData(object):
     def __init__(self, default_resolvers=None, default_private_subnets=None):
@@ -117,3 +120,13 @@ class NetworkData(object):
 
     def build_resolvers(self):
         self.resolvers = utils.resolvers(self.resolvers)
+
+    def as_dict(self):
+        return {
+            "bonding": self.bonding,
+            "interfaces": self.interfaces,
+            "bonds": self.bonds,
+            "addresses": self.addresses,
+            "resolvers": self.resolvers,
+            "private_subnets": self.private_subnets,
+        }

--- a/packetnetworking/cli.py
+++ b/packetnetworking/cli.py
@@ -96,7 +96,8 @@ def cli(
             )
             break
         except Exception as exc:
-            # If a metadata file has been passed, retrying won't result in a different outcome.
+            # If a metadata file has been passed, retrying won't result in a
+            # different outcome.
             if metadata_file:
                 raise
             if attempt == max_attempts:

--- a/packetnetworking/cli.py
+++ b/packetnetworking/cli.py
@@ -36,7 +36,12 @@ log = logging.getLogger("packetnetworking")
         + "(otherwise uses ones from /etc/resolv.conf)"
     ),
 )
-@click.option("-n", "--max-attempts", default=10, help="retry up to N times on failure")
+@click.option(
+    "-n",
+    "--max-attempts",
+    default=10,
+    help="Retry up to N times on failure when downloading metadata from a url",
+)
 @click.option("-v", "--verbose", count=True, help="Provide more detailed output")
 @click.option("-q", "--quiet", is_flag=True, help="Silences all output")
 def cli(
@@ -91,6 +96,9 @@ def cli(
             )
             break
         except Exception as exc:
+            # If a metadata file has been passed, retrying won't result in a different outcome.
+            if metadata_file:
+                raise
             if attempt == max_attempts:
                 raise
             attempt += 1

--- a/packetnetworking/distros/distro_builder.py
+++ b/packetnetworking/distros/distro_builder.py
@@ -109,6 +109,7 @@ class DistroBuilder(Tasks):
                     tasks.update(builder.tasks)
         return tasks
 
+    # pylama:ignore=C901
     def render(self):
         """
         Render compiles each task template into the final content.
@@ -166,9 +167,8 @@ class DistroBuilder(Tasks):
                     file=sys.stderr,
                 )
                 log.error(
-                    "An exception occured while processing task '{}' with template:\n{}".format(
-                        path, template
-                    )
+                    "An exception occured while processing task "
+                    + "'{}' with template:\n{}".format(path, template)
                 )
                 raise
         return rendered_tasks

--- a/packetnetworking/distros/distro_builder.py
+++ b/packetnetworking/distros/distro_builder.py
@@ -1,9 +1,11 @@
 import os
 import sys
 import logging
+import json
 from textwrap import dedent
 
 from jinja2 import Template, StrictUndefined
+from jinja2.exceptions import UndefinedError
 
 from ..utils import Tasks, package_dir
 
@@ -139,21 +141,36 @@ class DistroBuilder(Tasks):
                 if fmt:
                     template = template.format(**fmt)
 
-            template = Template(
-                dedent(template),
+            template = dedent(template)
+            tmpl = Template(
+                template,
                 keep_trailing_newline=True,
                 lstrip_blocks=True,
                 trim_blocks=True,
                 undefined=StrictUndefined,
             )
-            if file_mode or mode:
-                rendered_tasks[path] = {
-                    "file_mode": file_mode,
-                    "mode": mode,
-                    "content": template.render(self.context()),
-                }
-            else:
-                rendered_tasks[path] = template.render(self.context())
+            try:
+                if file_mode or mode:
+                    rendered_tasks[path] = {
+                        "file_mode": file_mode,
+                        "mode": mode,
+                        "content": tmpl.render(self.context()),
+                    }
+                else:
+                    rendered_tasks[path] = tmpl.render(self.context())
+            except UndefinedError:
+                # having to use print as log.* isn't printing out the json
+                print(
+                    "==== METADATA ====\n"
+                    + json.dumps(self.metadata.as_dict(), indent=2),
+                    file=sys.stderr,
+                )
+                log.error(
+                    "An exception occured while processing task '{}' with template:\n{}".format(
+                        path, template
+                    )
+                )
+                raise
         return rendered_tasks
 
     def run(self, rootfs_path):


### PR DESCRIPTION
This should dump some additional data as seen by the tool to help with failed template renders. Below is an example of the output if no ip addresses are specified.

```# packet-networking -M /tmp/metadata.json -t ./rootfs/
...
==== METADATA ====
{
  "metadata": {
...
    "network": {
...
      "addresses": []
    },
...
  },
  "network": {
...
    },
    "addresses": [],
    "resolvers": [
      "192.168.1.1"
    ]
  }
}
ERROR:root:An exception occured while processing task 'etc/sysconfig/network-scripts/ifcfg-bond0' with template:
DEVICE=bond0
NAME=bond0
{% if ip4pub %}
IPADDR={{ ip4pub.address }}

...

  File "<template>", line 10, in top-level template code
jinja2.exceptions.UndefinedError: 'None' has no attribute 'address'
```