### PR TITLE
utils: Disable lshw framebuffer test

### DIFF
--- a/packetnetworking/utils.py
+++ b/packetnetworking/utils.py
@@ -275,7 +275,8 @@ def get_output(cmd):
 
 
 def get_lshw_info():
-    return json.loads(get_output(["lshw", "-json"]).decode())
+    # Workaround for x.large.arm: Skip framebuffer test ("-disable fb")
+    return json.loads(get_output(["lshw", "-json", "-disable", "fb"]).decode())
 
 
 def pam(arg, *funcs):


### PR DESCRIPTION
On the x.large.arm, lshw adds fb0 details to the node belonging
to eth0.  Since we currently have no need to record framebuffer
details, we can disable the framebuffer test until the lshw issue
is properly debugged.