### PR TITLE
resolve symlink paths before writing file

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -15,7 +15,7 @@ pipeline:
     commands:
       - pip install black==19.3b0 pylama
       - black --check --diff .
-      - pylama packetnetworking setup.py
+      - pylama --ignore=E203 packetnetworking setup.py
 
   test:
     image: python:${PYTHON_VERSION}

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,3 +1,7 @@
+clone:
+  git:
+    image: quay.io/packet/drone-git
+
 matrix:
   PYTHON_VERSION:
     - 3.5

--- a/packetnetworking/distros/distro_builder.py
+++ b/packetnetworking/distros/distro_builder.py
@@ -7,7 +7,7 @@ from textwrap import dedent
 from jinja2 import Template, StrictUndefined
 from jinja2.exceptions import UndefinedError
 
-from ..utils import Tasks, package_dir
+from .. import utils
 
 log = logging.getLogger()
 
@@ -16,10 +16,10 @@ def get_templates_dir(instance):
     instance_dir = os.path.abspath(
         os.path.dirname(sys.modules[instance.__class__.__module__].__file__)
     )
-    return os.path.join(os.path.relpath(instance_dir, package_dir), "templates")
+    return os.path.join(os.path.relpath(instance_dir, utils.package_dir), "templates")
 
 
-class DistroBuilder(Tasks):
+class DistroBuilder(utils.Tasks):
     distros = None
     network_builders = []
 

--- a/packetnetworking/distros/distro_builder.py
+++ b/packetnetworking/distros/distro_builder.py
@@ -193,6 +193,9 @@ class DistroBuilder(utils.Tasks):
                     )
                 continue
 
+            # Resolve symlinks to write to the destination file
+            abspath = utils.resolve_path(rootfs_path, relpath)
+
             file_mode = "w"
             mode = None
             if isinstance(content, dict):

--- a/packetnetworking/test_utils.py
+++ b/packetnetworking/test_utils.py
@@ -1,0 +1,87 @@
+from . import utils
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "abspath",
+    [
+        pytest.param(False, id="Not using abs path"),
+        pytest.param(True, id="Using abs path"),
+    ],
+)
+@pytest.mark.parametrize(
+    "initdepth,recerr,islinkcnt,readlinkcnt",
+    [
+        pytest.param(0, False, 2, 1, id="Depth: 0"),
+        pytest.param(1, False, 2, 1, id="Init Depth: 1"),
+        pytest.param(
+            utils.MAX_RESOLVE_DEPTH - 1, False, 2, 1, id="Init Depth: MAX - 1"
+        ),
+        pytest.param(utils.MAX_RESOLVE_DEPTH, True, 1, 1, id="Init Depth: MAX"),
+        pytest.param(utils.MAX_RESOLVE_DEPTH + 1, True, 0, 0, id="Init Depth: MAX + 1"),
+    ],
+)
+@pytest.mark.parametrize(
+    "path,link,expected",
+    [
+        pytest.param("/etc/resolv.conf", None, "/etc/resolv.conf", id="Regular file"),
+        pytest.param(
+            "/etc/resolv.conf",
+            "/etc/resolv.conf.d/default.resolv.conf",
+            "/etc/resolv.conf.d/default.resolv.conf",
+            id="Absolute reference",
+        ),
+        pytest.param(
+            "/etc/resolv.conf",
+            "./resolv.conf.d/default.resolv.conf",
+            "/etc/resolv.conf.d/default.resolv.conf",
+            id="./ reference",
+        ),
+        pytest.param(
+            "/etc/resolv.conf",
+            "../etc/resolv.conf.d/default.resolv.conf",
+            "/etc/resolv.conf.d/default.resolv.conf",
+            id="../ reference",
+        ),
+        pytest.param(
+            "/etc/resolv.conf",
+            "../../../../etc/resolv.conf.d/default.resolv.conf",
+            "/etc/resolv.conf.d/default.resolv.conf",
+            id="../ reference (above root)",
+        ),
+    ],
+)
+def test_resolve_path(
+    abspath, path, link, expected, initdepth, recerr, islinkcnt, readlinkcnt
+):
+    rootfs = "/mnt/target"
+    expected = rootfs + expected
+    if abspath:
+        path = rootfs + path
+
+    # If not a symlink, no recursion should happen
+    if not link:
+        if islinkcnt > 1:
+            islinkcnt = islinkcnt - 1
+        if readlinkcnt > 0:
+            readlinkcnt = readlinkcnt - 1
+            if readlinkcnt == 0:
+                # RecursionError should not be hit
+                recerr = False
+
+    with patch("os.path.islink") as mocked_islink:
+        mocked_islink.side_effect = [True if link else False, False]
+        with patch("os.readlink") as mocked_readlink:
+            mocked_readlink.return_value = link
+            if recerr:
+                with pytest.raises(RecursionError):
+                    result = utils.resolve_path(rootfs, path, _depth=initdepth)
+            else:
+                result = utils.resolve_path(rootfs, path, _depth=initdepth)
+
+    assert mocked_islink.call_count == islinkcnt
+    assert mocked_readlink.call_count == readlinkcnt
+    if not recerr:
+        assert result == expected


### PR DESCRIPTION
It's possible that an os could have a path already exist as a symlink without the linked
file existing. In python this results in an error `FileNotFoundError: [Errno 2] No such file or directory`

To get around this, we'll resolve any symlink paths first, before attempting to write to the file.