### PR TITLE
Fix Ubuntu etc/network/interfaces ordering

### DIFF
--- a/packetnetworking/distros/debian/templates/bonded/etc_network_interfaces.j2
+++ b/packetnetworking/distros/debian/templates/bonded/etc_network_interfaces.j2
@@ -1,6 +1,17 @@
 auto lo
 iface lo inet loopback
 
+{% if osinfo.distro == 'ubuntu' %}
+{% for iface in interfaces %}
+auto {{ iface.name }}
+iface {{ iface.name }} inet manual
+{% if iface.name != interfaces[0].name %}
+    pre-up sleep 4
+{% endif %}
+    bond-master bond0
+
+{% endfor %}
+{% endif %}
 auto bond0
 iface bond0 inet static
     {% if ip4pub %}
@@ -40,15 +51,4 @@ iface bond0:0 inet static
     post-up route add -net {{ subnet }} gw {{ ip4priv.gateway }}
     post-down route del -net {{ subnet }} gw {{ ip4priv.gateway }}
     {% endfor %}
-{% endif %}
-{% if osinfo.distro == 'ubuntu' %}
-{% for iface in interfaces %}
-
-auto {{ iface.name }}
-iface {{ iface.name }} inet manual
-{% if iface.name != interfaces[0].name %}
-    pre-up sleep 4
-{% endif %}
-    bond-master bond0
-{% endfor %}
 {% endif %}

--- a/packetnetworking/distros/debian/test_ubuntu_1404_bonded.py
+++ b/packetnetworking/distros/debian/test_ubuntu_1404_bonded.py
@@ -22,6 +22,15 @@ def test_ubuntu_1404_public_bonded_task_etc_network_interfaces(
         auto lo
         iface lo inet loopback
 
+        auto {iface0.name}
+        iface {iface0.name} inet manual
+            bond-master bond0
+
+        auto {iface1.name}
+        iface {iface1.name} inet manual
+            pre-up sleep 4
+            bond-master bond0
+
         auto bond0
         iface bond0 inet static
             address {ipv4pub.address}
@@ -46,15 +55,6 @@ def test_ubuntu_1404_public_bonded_task_etc_network_interfaces(
             netmask {ipv4priv.netmask}
             post-up route add -net 10.0.0.0/8 gw {ipv4priv.gateway}
             post-down route del -net 10.0.0.0/8 gw {ipv4priv.gateway}
-
-        auto {iface0.name}
-        iface {iface0.name} inet manual
-            bond-master bond0
-
-        auto {iface1.name}
-        iface {iface1.name} inet manual
-            pre-up sleep 4
-            bond-master bond0
     """
     ).format(
         ipv4pub=builder.ipv4pub.first,
@@ -83,6 +83,15 @@ def test_ubuntu_1404_private_bonded_task_etc_network_interfaces(
         auto lo
         iface lo inet loopback
 
+        auto {iface0.name}
+        iface {iface0.name} inet manual
+            bond-master bond0
+
+        auto {iface1.name}
+        iface {iface1.name} inet manual
+            pre-up sleep 4
+            bond-master bond0
+
         auto bond0
         iface bond0 inet static
             address {ipv4priv.address}
@@ -97,15 +106,6 @@ def test_ubuntu_1404_private_bonded_task_etc_network_interfaces(
             bond-slaves {iface0.name} {iface1.name}
             dns-nameservers {dns1} {dns2}
 
-
-        auto {iface0.name}
-        iface {iface0.name} inet manual
-            bond-master bond0
-
-        auto {iface1.name}
-        iface {iface1.name} inet manual
-            pre-up sleep 4
-            bond-master bond0
     """
     ).format(
         ipv4priv=builder.ipv4priv.first,
@@ -129,6 +129,15 @@ def test_ubuntu_1404_public_bonded_task_etc_network_interfaces_with_custom_priva
         """\
         auto lo
         iface lo inet loopback
+
+        auto {iface0.name}
+        iface {iface0.name} inet manual
+            bond-master bond0
+
+        auto {iface1.name}
+        iface {iface1.name} inet manual
+            pre-up sleep 4
+            bond-master bond0
 
         auto bond0
         iface bond0 inet static
@@ -156,15 +165,6 @@ def test_ubuntu_1404_public_bonded_task_etc_network_interfaces_with_custom_priva
             post-down route del -net 192.168.5.0/24 gw {ipv4priv.gateway}
             post-up route add -net 172.16.0.0/12 gw {ipv4priv.gateway}
             post-down route del -net 172.16.0.0/12 gw {ipv4priv.gateway}
-
-        auto {iface0.name}
-        iface {iface0.name} inet manual
-            bond-master bond0
-
-        auto {iface1.name}
-        iface {iface1.name} inet manual
-            pre-up sleep 4
-            bond-master bond0
     """
     ).format(
         ipv4pub=builder.ipv4pub.first,
@@ -194,6 +194,15 @@ def test_ubuntu_1404_private_bonded_task_etc_network_interfaces_with_custom_priv
         auto lo
         iface lo inet loopback
 
+        auto {iface0.name}
+        iface {iface0.name} inet manual
+            bond-master bond0
+
+        auto {iface1.name}
+        iface {iface1.name} inet manual
+            pre-up sleep 4
+            bond-master bond0
+
         auto bond0
         iface bond0 inet static
             address {ipv4priv.address}
@@ -208,15 +217,6 @@ def test_ubuntu_1404_private_bonded_task_etc_network_interfaces_with_custom_priv
             bond-slaves {iface0.name} {iface1.name}
             dns-nameservers {dns1} {dns2}
 
-
-        auto {iface0.name}
-        iface {iface0.name} inet manual
-            bond-master bond0
-
-        auto {iface1.name}
-        iface {iface1.name} inet manual
-            pre-up sleep 4
-            bond-master bond0
     """
     ).format(
         ipv4priv=builder.ipv4priv.first,

--- a/packetnetworking/distros/debian/test_ubuntu_1604_bonded.py
+++ b/packetnetworking/distros/debian/test_ubuntu_1604_bonded.py
@@ -22,6 +22,15 @@ def test_ubuntu_1604_public_bonded_task_etc_network_interfaces(
         auto lo
         iface lo inet loopback
 
+        auto {iface0.name}
+        iface {iface0.name} inet manual
+            bond-master bond0
+
+        auto {iface1.name}
+        iface {iface1.name} inet manual
+            pre-up sleep 4
+            bond-master bond0
+
         auto bond0
         iface bond0 inet static
             address {ipv4pub.address}
@@ -46,15 +55,6 @@ def test_ubuntu_1604_public_bonded_task_etc_network_interfaces(
             netmask {ipv4priv.netmask}
             post-up route add -net 10.0.0.0/8 gw {ipv4priv.gateway}
             post-down route del -net 10.0.0.0/8 gw {ipv4priv.gateway}
-
-        auto {iface0.name}
-        iface {iface0.name} inet manual
-            bond-master bond0
-
-        auto {iface1.name}
-        iface {iface1.name} inet manual
-            pre-up sleep 4
-            bond-master bond0
     """
     ).format(
         ipv4pub=builder.ipv4pub.first,
@@ -83,6 +83,15 @@ def test_ubuntu_1604_private_bonded_task_etc_network_interfaces(
         auto lo
         iface lo inet loopback
 
+        auto {iface0.name}
+        iface {iface0.name} inet manual
+            bond-master bond0
+
+        auto {iface1.name}
+        iface {iface1.name} inet manual
+            pre-up sleep 4
+            bond-master bond0
+
         auto bond0
         iface bond0 inet static
             address {ipv4priv.address}
@@ -97,15 +106,6 @@ def test_ubuntu_1604_private_bonded_task_etc_network_interfaces(
             bond-slaves {iface0.name} {iface1.name}
             dns-nameservers {dns1} {dns2}
 
-
-        auto {iface0.name}
-        iface {iface0.name} inet manual
-            bond-master bond0
-
-        auto {iface1.name}
-        iface {iface1.name} inet manual
-            pre-up sleep 4
-            bond-master bond0
     """
     ).format(
         ipv4priv=builder.ipv4priv.first,
@@ -129,6 +129,15 @@ def test_ubuntu_1604_public_bonded_task_etc_network_interfaces_with_custom_priva
         """\
         auto lo
         iface lo inet loopback
+
+        auto {iface0.name}
+        iface {iface0.name} inet manual
+            bond-master bond0
+
+        auto {iface1.name}
+        iface {iface1.name} inet manual
+            pre-up sleep 4
+            bond-master bond0
 
         auto bond0
         iface bond0 inet static
@@ -156,15 +165,6 @@ def test_ubuntu_1604_public_bonded_task_etc_network_interfaces_with_custom_priva
             post-down route del -net 192.168.5.0/24 gw {ipv4priv.gateway}
             post-up route add -net 172.16.0.0/12 gw {ipv4priv.gateway}
             post-down route del -net 172.16.0.0/12 gw {ipv4priv.gateway}
-
-        auto {iface0.name}
-        iface {iface0.name} inet manual
-            bond-master bond0
-
-        auto {iface1.name}
-        iface {iface1.name} inet manual
-            pre-up sleep 4
-            bond-master bond0
     """
     ).format(
         ipv4pub=builder.ipv4pub.first,
@@ -194,6 +194,15 @@ def test_ubuntu_1604_private_bonded_task_etc_network_interfaces_with_custom_priv
         auto lo
         iface lo inet loopback
 
+        auto {iface0.name}
+        iface {iface0.name} inet manual
+            bond-master bond0
+
+        auto {iface1.name}
+        iface {iface1.name} inet manual
+            pre-up sleep 4
+            bond-master bond0
+
         auto bond0
         iface bond0 inet static
             address {ipv4priv.address}
@@ -208,15 +217,6 @@ def test_ubuntu_1604_private_bonded_task_etc_network_interfaces_with_custom_priv
             bond-slaves {iface0.name} {iface1.name}
             dns-nameservers {dns1} {dns2}
 
-
-        auto {iface0.name}
-        iface {iface0.name} inet manual
-            bond-master bond0
-
-        auto {iface1.name}
-        iface {iface1.name} inet manual
-            pre-up sleep 4
-            bond-master bond0
     """
     ).format(
         ipv4priv=builder.ipv4priv.first,

--- a/packetnetworking/distros/debian/test_ubuntu_1804_bonded.py
+++ b/packetnetworking/distros/debian/test_ubuntu_1804_bonded.py
@@ -22,6 +22,15 @@ def test_ubuntu_1804_public_bonded_task_etc_network_interfaces(
         auto lo
         iface lo inet loopback
 
+        auto {iface0.name}
+        iface {iface0.name} inet manual
+            bond-master bond0
+
+        auto {iface1.name}
+        iface {iface1.name} inet manual
+            pre-up sleep 4
+            bond-master bond0
+
         auto bond0
         iface bond0 inet static
             address {ipv4pub.address}
@@ -46,15 +55,6 @@ def test_ubuntu_1804_public_bonded_task_etc_network_interfaces(
             netmask {ipv4priv.netmask}
             post-up route add -net 10.0.0.0/8 gw {ipv4priv.gateway}
             post-down route del -net 10.0.0.0/8 gw {ipv4priv.gateway}
-
-        auto {iface0.name}
-        iface {iface0.name} inet manual
-            bond-master bond0
-
-        auto {iface1.name}
-        iface {iface1.name} inet manual
-            pre-up sleep 4
-            bond-master bond0
     """
     ).format(
         ipv4pub=builder.ipv4pub.first,
@@ -83,6 +83,15 @@ def test_ubuntu_1804_private_bonded_task_etc_network_interfaces(
         auto lo
         iface lo inet loopback
 
+        auto {iface0.name}
+        iface {iface0.name} inet manual
+            bond-master bond0
+
+        auto {iface1.name}
+        iface {iface1.name} inet manual
+            pre-up sleep 4
+            bond-master bond0
+
         auto bond0
         iface bond0 inet static
             address {ipv4priv.address}
@@ -97,15 +106,6 @@ def test_ubuntu_1804_private_bonded_task_etc_network_interfaces(
             bond-slaves {iface0.name} {iface1.name}
             dns-nameservers {dns1} {dns2}
 
-
-        auto {iface0.name}
-        iface {iface0.name} inet manual
-            bond-master bond0
-
-        auto {iface1.name}
-        iface {iface1.name} inet manual
-            pre-up sleep 4
-            bond-master bond0
     """
     ).format(
         ipv4priv=builder.ipv4priv.first,
@@ -129,6 +129,15 @@ def test_ubuntu_1804_public_bonded_task_etc_network_interfaces_with_custom_priva
         """\
         auto lo
         iface lo inet loopback
+
+        auto {iface0.name}
+        iface {iface0.name} inet manual
+            bond-master bond0
+
+        auto {iface1.name}
+        iface {iface1.name} inet manual
+            pre-up sleep 4
+            bond-master bond0
 
         auto bond0
         iface bond0 inet static
@@ -156,15 +165,6 @@ def test_ubuntu_1804_public_bonded_task_etc_network_interfaces_with_custom_priva
             post-down route del -net 192.168.5.0/24 gw {ipv4priv.gateway}
             post-up route add -net 172.16.0.0/12 gw {ipv4priv.gateway}
             post-down route del -net 172.16.0.0/12 gw {ipv4priv.gateway}
-
-        auto {iface0.name}
-        iface {iface0.name} inet manual
-            bond-master bond0
-
-        auto {iface1.name}
-        iface {iface1.name} inet manual
-            pre-up sleep 4
-            bond-master bond0
     """
     ).format(
         ipv4pub=builder.ipv4pub.first,
@@ -194,6 +194,15 @@ def test_ubuntu_1804_private_bonded_task_etc_network_interfaces_with_custom_priv
         auto lo
         iface lo inet loopback
 
+        auto {iface0.name}
+        iface {iface0.name} inet manual
+            bond-master bond0
+
+        auto {iface1.name}
+        iface {iface1.name} inet manual
+            pre-up sleep 4
+            bond-master bond0
+
         auto bond0
         iface bond0 inet static
             address {ipv4priv.address}
@@ -208,15 +217,6 @@ def test_ubuntu_1804_private_bonded_task_etc_network_interfaces_with_custom_priv
             bond-slaves {iface0.name} {iface1.name}
             dns-nameservers {dns1} {dns2}
 
-
-        auto {iface0.name}
-        iface {iface0.name} inet manual
-            bond-master bond0
-
-        auto {iface1.name}
-        iface {iface1.name} inet manual
-            pre-up sleep 4
-            bond-master bond0
     """
     ).format(
         ipv4priv=builder.ipv4priv.first,

--- a/packetnetworking/distros/debian/test_ubuntu_1904_bonded.py
+++ b/packetnetworking/distros/debian/test_ubuntu_1904_bonded.py
@@ -22,6 +22,15 @@ def test_ubuntu_1904_public_bonded_task_etc_network_interfaces(
         auto lo
         iface lo inet loopback
 
+        auto {iface0.name}
+        iface {iface0.name} inet manual
+            bond-master bond0
+
+        auto {iface1.name}
+        iface {iface1.name} inet manual
+            pre-up sleep 4
+            bond-master bond0
+
         auto bond0
         iface bond0 inet static
             address {ipv4pub.address}
@@ -46,15 +55,6 @@ def test_ubuntu_1904_public_bonded_task_etc_network_interfaces(
             netmask {ipv4priv.netmask}
             post-up route add -net 10.0.0.0/8 gw {ipv4priv.gateway}
             post-down route del -net 10.0.0.0/8 gw {ipv4priv.gateway}
-
-        auto {iface0.name}
-        iface {iface0.name} inet manual
-            bond-master bond0
-
-        auto {iface1.name}
-        iface {iface1.name} inet manual
-            pre-up sleep 4
-            bond-master bond0
     """
     ).format(
         ipv4pub=builder.ipv4pub.first,
@@ -83,6 +83,15 @@ def test_ubuntu_1904_private_bonded_task_etc_network_interfaces(
         auto lo
         iface lo inet loopback
 
+        auto {iface0.name}
+        iface {iface0.name} inet manual
+            bond-master bond0
+
+        auto {iface1.name}
+        iface {iface1.name} inet manual
+            pre-up sleep 4
+            bond-master bond0
+
         auto bond0
         iface bond0 inet static
             address {ipv4priv.address}
@@ -97,15 +106,6 @@ def test_ubuntu_1904_private_bonded_task_etc_network_interfaces(
             bond-slaves {iface0.name} {iface1.name}
             dns-nameservers {dns1} {dns2}
 
-
-        auto {iface0.name}
-        iface {iface0.name} inet manual
-            bond-master bond0
-
-        auto {iface1.name}
-        iface {iface1.name} inet manual
-            pre-up sleep 4
-            bond-master bond0
     """
     ).format(
         ipv4priv=builder.ipv4priv.first,
@@ -129,6 +129,15 @@ def test_ubuntu_1904_public_bonded_task_etc_network_interfaces_with_custom_priva
         """\
         auto lo
         iface lo inet loopback
+
+        auto {iface0.name}
+        iface {iface0.name} inet manual
+            bond-master bond0
+
+        auto {iface1.name}
+        iface {iface1.name} inet manual
+            pre-up sleep 4
+            bond-master bond0
 
         auto bond0
         iface bond0 inet static
@@ -156,15 +165,6 @@ def test_ubuntu_1904_public_bonded_task_etc_network_interfaces_with_custom_priva
             post-down route del -net 192.168.5.0/24 gw {ipv4priv.gateway}
             post-up route add -net 172.16.0.0/12 gw {ipv4priv.gateway}
             post-down route del -net 172.16.0.0/12 gw {ipv4priv.gateway}
-
-        auto {iface0.name}
-        iface {iface0.name} inet manual
-            bond-master bond0
-
-        auto {iface1.name}
-        iface {iface1.name} inet manual
-            pre-up sleep 4
-            bond-master bond0
     """
     ).format(
         ipv4pub=builder.ipv4pub.first,
@@ -194,6 +194,15 @@ def test_ubuntu_1904_private_bonded_task_etc_network_interfaces_with_custom_priv
         auto lo
         iface lo inet loopback
 
+        auto {iface0.name}
+        iface {iface0.name} inet manual
+            bond-master bond0
+
+        auto {iface1.name}
+        iface {iface1.name} inet manual
+            pre-up sleep 4
+            bond-master bond0
+
         auto bond0
         iface bond0 inet static
             address {ipv4priv.address}
@@ -208,15 +217,6 @@ def test_ubuntu_1904_private_bonded_task_etc_network_interfaces_with_custom_priv
             bond-slaves {iface0.name} {iface1.name}
             dns-nameservers {dns1} {dns2}
 
-
-        auto {iface0.name}
-        iface {iface0.name} inet manual
-            bond-master bond0
-
-        auto {iface1.name}
-        iface {iface1.name} inet manual
-            pre-up sleep 4
-            bond-master bond0
     """
     ).format(
         ipv4priv=builder.ipv4priv.first,

--- a/packetnetworking/distros/debian/test_ubuntu_1910_bonded.py
+++ b/packetnetworking/distros/debian/test_ubuntu_1910_bonded.py
@@ -22,6 +22,15 @@ def test_ubuntu_1910_public_bonded_task_etc_network_interfaces(
         auto lo
         iface lo inet loopback
 
+        auto {iface0.name}
+        iface {iface0.name} inet manual
+            bond-master bond0
+
+        auto {iface1.name}
+        iface {iface1.name} inet manual
+            pre-up sleep 4
+            bond-master bond0
+
         auto bond0
         iface bond0 inet static
             address {ipv4pub.address}
@@ -46,15 +55,6 @@ def test_ubuntu_1910_public_bonded_task_etc_network_interfaces(
             netmask {ipv4priv.netmask}
             post-up route add -net 10.0.0.0/8 gw {ipv4priv.gateway}
             post-down route del -net 10.0.0.0/8 gw {ipv4priv.gateway}
-
-        auto {iface0.name}
-        iface {iface0.name} inet manual
-            bond-master bond0
-
-        auto {iface1.name}
-        iface {iface1.name} inet manual
-            pre-up sleep 4
-            bond-master bond0
     """
     ).format(
         ipv4pub=builder.ipv4pub.first,
@@ -83,6 +83,15 @@ def test_ubuntu_1910_private_bonded_task_etc_network_interfaces(
         auto lo
         iface lo inet loopback
 
+        auto {iface0.name}
+        iface {iface0.name} inet manual
+            bond-master bond0
+
+        auto {iface1.name}
+        iface {iface1.name} inet manual
+            pre-up sleep 4
+            bond-master bond0
+
         auto bond0
         iface bond0 inet static
             address {ipv4priv.address}
@@ -97,15 +106,6 @@ def test_ubuntu_1910_private_bonded_task_etc_network_interfaces(
             bond-slaves {iface0.name} {iface1.name}
             dns-nameservers {dns1} {dns2}
 
-
-        auto {iface0.name}
-        iface {iface0.name} inet manual
-            bond-master bond0
-
-        auto {iface1.name}
-        iface {iface1.name} inet manual
-            pre-up sleep 4
-            bond-master bond0
     """
     ).format(
         ipv4priv=builder.ipv4priv.first,
@@ -129,6 +129,15 @@ def test_ubuntu_1910_public_bonded_task_etc_network_interfaces_with_custom_priva
         """\
         auto lo
         iface lo inet loopback
+
+        auto {iface0.name}
+        iface {iface0.name} inet manual
+            bond-master bond0
+
+        auto {iface1.name}
+        iface {iface1.name} inet manual
+            pre-up sleep 4
+            bond-master bond0
 
         auto bond0
         iface bond0 inet static
@@ -156,15 +165,6 @@ def test_ubuntu_1910_public_bonded_task_etc_network_interfaces_with_custom_priva
             post-down route del -net 192.168.5.0/24 gw {ipv4priv.gateway}
             post-up route add -net 172.16.0.0/12 gw {ipv4priv.gateway}
             post-down route del -net 172.16.0.0/12 gw {ipv4priv.gateway}
-
-        auto {iface0.name}
-        iface {iface0.name} inet manual
-            bond-master bond0
-
-        auto {iface1.name}
-        iface {iface1.name} inet manual
-            pre-up sleep 4
-            bond-master bond0
     """
     ).format(
         ipv4pub=builder.ipv4pub.first,
@@ -194,6 +194,15 @@ def test_ubuntu_1910_private_bonded_task_etc_network_interfaces_with_custom_priv
         auto lo
         iface lo inet loopback
 
+        auto {iface0.name}
+        iface {iface0.name} inet manual
+            bond-master bond0
+
+        auto {iface1.name}
+        iface {iface1.name} inet manual
+            pre-up sleep 4
+            bond-master bond0
+
         auto bond0
         iface bond0 inet static
             address {ipv4priv.address}
@@ -208,15 +217,6 @@ def test_ubuntu_1910_private_bonded_task_etc_network_interfaces_with_custom_priv
             bond-slaves {iface0.name} {iface1.name}
             dns-nameservers {dns1} {dns2}
 
-
-        auto {iface0.name}
-        iface {iface0.name} inet manual
-            bond-master bond0
-
-        auto {iface1.name}
-        iface {iface1.name} inet manual
-            pre-up sleep 4
-            bond-master bond0
     """
     ).format(
         ipv4priv=builder.ipv4priv.first,

--- a/packetnetworking/distros/debian/test_ubuntu_2004_bonded.py
+++ b/packetnetworking/distros/debian/test_ubuntu_2004_bonded.py
@@ -22,6 +22,15 @@ def test_ubuntu_2004_public_bonded_task_etc_network_interfaces(
         auto lo
         iface lo inet loopback
 
+        auto {iface0.name}
+        iface {iface0.name} inet manual
+            bond-master bond0
+
+        auto {iface1.name}
+        iface {iface1.name} inet manual
+            pre-up sleep 4
+            bond-master bond0
+
         auto bond0
         iface bond0 inet static
             address {ipv4pub.address}
@@ -46,15 +55,6 @@ def test_ubuntu_2004_public_bonded_task_etc_network_interfaces(
             netmask {ipv4priv.netmask}
             post-up route add -net 10.0.0.0/8 gw {ipv4priv.gateway}
             post-down route del -net 10.0.0.0/8 gw {ipv4priv.gateway}
-
-        auto {iface0.name}
-        iface {iface0.name} inet manual
-            bond-master bond0
-
-        auto {iface1.name}
-        iface {iface1.name} inet manual
-            pre-up sleep 4
-            bond-master bond0
     """
     ).format(
         ipv4pub=builder.ipv4pub.first,
@@ -83,6 +83,15 @@ def test_ubuntu_2004_private_bonded_task_etc_network_interfaces(
         auto lo
         iface lo inet loopback
 
+        auto {iface0.name}
+        iface {iface0.name} inet manual
+            bond-master bond0
+
+        auto {iface1.name}
+        iface {iface1.name} inet manual
+            pre-up sleep 4
+            bond-master bond0
+
         auto bond0
         iface bond0 inet static
             address {ipv4priv.address}
@@ -97,15 +106,6 @@ def test_ubuntu_2004_private_bonded_task_etc_network_interfaces(
             bond-slaves {iface0.name} {iface1.name}
             dns-nameservers {dns1} {dns2}
 
-
-        auto {iface0.name}
-        iface {iface0.name} inet manual
-            bond-master bond0
-
-        auto {iface1.name}
-        iface {iface1.name} inet manual
-            pre-up sleep 4
-            bond-master bond0
     """
     ).format(
         ipv4priv=builder.ipv4priv.first,
@@ -129,6 +129,15 @@ def test_ubuntu_2004_public_bonded_task_etc_network_interfaces_with_custom_priva
         """\
         auto lo
         iface lo inet loopback
+
+        auto {iface0.name}
+        iface {iface0.name} inet manual
+            bond-master bond0
+
+        auto {iface1.name}
+        iface {iface1.name} inet manual
+            pre-up sleep 4
+            bond-master bond0
 
         auto bond0
         iface bond0 inet static
@@ -156,15 +165,6 @@ def test_ubuntu_2004_public_bonded_task_etc_network_interfaces_with_custom_priva
             post-down route del -net 192.168.5.0/24 gw {ipv4priv.gateway}
             post-up route add -net 172.16.0.0/12 gw {ipv4priv.gateway}
             post-down route del -net 172.16.0.0/12 gw {ipv4priv.gateway}
-
-        auto {iface0.name}
-        iface {iface0.name} inet manual
-            bond-master bond0
-
-        auto {iface1.name}
-        iface {iface1.name} inet manual
-            pre-up sleep 4
-            bond-master bond0
     """
     ).format(
         ipv4pub=builder.ipv4pub.first,
@@ -194,6 +194,15 @@ def test_ubuntu_2004_private_bonded_task_etc_network_interfaces_with_custom_priv
         auto lo
         iface lo inet loopback
 
+        auto {iface0.name}
+        iface {iface0.name} inet manual
+            bond-master bond0
+
+        auto {iface1.name}
+        iface {iface1.name} inet manual
+            pre-up sleep 4
+            bond-master bond0
+
         auto bond0
         iface bond0 inet static
             address {ipv4priv.address}
@@ -208,15 +217,6 @@ def test_ubuntu_2004_private_bonded_task_etc_network_interfaces_with_custom_priv
             bond-slaves {iface0.name} {iface1.name}
             dns-nameservers {dns1} {dns2}
 
-
-        auto {iface0.name}
-        iface {iface0.name} inet manual
-            bond-master bond0
-
-        auto {iface1.name}
-        iface {iface1.name} inet manual
-            pre-up sleep 4
-            bond-master bond0
     """
     ).format(
         ipv4priv=builder.ipv4priv.first,

--- a/packetnetworking/distros/debian/test_ubuntu_2010_bonded.py
+++ b/packetnetworking/distros/debian/test_ubuntu_2010_bonded.py
@@ -22,6 +22,15 @@ def test_ubuntu_2010_public_bonded_task_etc_network_interfaces(
         auto lo
         iface lo inet loopback
 
+        auto {iface0.name}
+        iface {iface0.name} inet manual
+            bond-master bond0
+
+        auto {iface1.name}
+        iface {iface1.name} inet manual
+            pre-up sleep 4
+            bond-master bond0
+
         auto bond0
         iface bond0 inet static
             address {ipv4pub.address}
@@ -46,15 +55,6 @@ def test_ubuntu_2010_public_bonded_task_etc_network_interfaces(
             netmask {ipv4priv.netmask}
             post-up route add -net 10.0.0.0/8 gw {ipv4priv.gateway}
             post-down route del -net 10.0.0.0/8 gw {ipv4priv.gateway}
-
-        auto {iface0.name}
-        iface {iface0.name} inet manual
-            bond-master bond0
-
-        auto {iface1.name}
-        iface {iface1.name} inet manual
-            pre-up sleep 4
-            bond-master bond0
     """
     ).format(
         ipv4pub=builder.ipv4pub.first,
@@ -83,6 +83,15 @@ def test_ubuntu_2010_private_bonded_task_etc_network_interfaces(
         auto lo
         iface lo inet loopback
 
+        auto {iface0.name}
+        iface {iface0.name} inet manual
+            bond-master bond0
+
+        auto {iface1.name}
+        iface {iface1.name} inet manual
+            pre-up sleep 4
+            bond-master bond0
+
         auto bond0
         iface bond0 inet static
             address {ipv4priv.address}
@@ -97,15 +106,6 @@ def test_ubuntu_2010_private_bonded_task_etc_network_interfaces(
             bond-slaves {iface0.name} {iface1.name}
             dns-nameservers {dns1} {dns2}
 
-
-        auto {iface0.name}
-        iface {iface0.name} inet manual
-            bond-master bond0
-
-        auto {iface1.name}
-        iface {iface1.name} inet manual
-            pre-up sleep 4
-            bond-master bond0
     """
     ).format(
         ipv4priv=builder.ipv4priv.first,
@@ -129,6 +129,15 @@ def test_ubuntu_2010_public_bonded_task_etc_network_interfaces_with_custom_priva
         """\
         auto lo
         iface lo inet loopback
+
+        auto {iface0.name}
+        iface {iface0.name} inet manual
+            bond-master bond0
+
+        auto {iface1.name}
+        iface {iface1.name} inet manual
+            pre-up sleep 4
+            bond-master bond0
 
         auto bond0
         iface bond0 inet static
@@ -156,15 +165,6 @@ def test_ubuntu_2010_public_bonded_task_etc_network_interfaces_with_custom_priva
             post-down route del -net 192.168.5.0/24 gw {ipv4priv.gateway}
             post-up route add -net 172.16.0.0/12 gw {ipv4priv.gateway}
             post-down route del -net 172.16.0.0/12 gw {ipv4priv.gateway}
-
-        auto {iface0.name}
-        iface {iface0.name} inet manual
-            bond-master bond0
-
-        auto {iface1.name}
-        iface {iface1.name} inet manual
-            pre-up sleep 4
-            bond-master bond0
     """
     ).format(
         ipv4pub=builder.ipv4pub.first,
@@ -194,6 +194,15 @@ def test_ubuntu_2010_private_bonded_task_etc_network_interfaces_with_custom_priv
         auto lo
         iface lo inet loopback
 
+        auto {iface0.name}
+        iface {iface0.name} inet manual
+            bond-master bond0
+
+        auto {iface1.name}
+        iface {iface1.name} inet manual
+            pre-up sleep 4
+            bond-master bond0
+
         auto bond0
         iface bond0 inet static
             address {ipv4priv.address}
@@ -208,15 +217,6 @@ def test_ubuntu_2010_private_bonded_task_etc_network_interfaces_with_custom_priv
             bond-slaves {iface0.name} {iface1.name}
             dns-nameservers {dns1} {dns2}
 
-
-        auto {iface0.name}
-        iface {iface0.name} inet manual
-            bond-master bond0
-
-        auto {iface1.name}
-        iface {iface1.name} inet manual
-            pre-up sleep 4
-            bond-master bond0
     """
     ).format(
         ipv4priv=builder.ipv4priv.first,

--- a/packetnetworking/distros/debian/test_ubuntu_2104_bonded.py
+++ b/packetnetworking/distros/debian/test_ubuntu_2104_bonded.py
@@ -22,6 +22,15 @@ def test_ubuntu_2104_public_bonded_task_etc_network_interfaces(
         auto lo
         iface lo inet loopback
 
+        auto {iface0.name}
+        iface {iface0.name} inet manual
+            bond-master bond0
+
+        auto {iface1.name}
+        iface {iface1.name} inet manual
+            pre-up sleep 4
+            bond-master bond0
+
         auto bond0
         iface bond0 inet static
             address {ipv4pub.address}
@@ -46,15 +55,6 @@ def test_ubuntu_2104_public_bonded_task_etc_network_interfaces(
             netmask {ipv4priv.netmask}
             post-up route add -net 10.0.0.0/8 gw {ipv4priv.gateway}
             post-down route del -net 10.0.0.0/8 gw {ipv4priv.gateway}
-
-        auto {iface0.name}
-        iface {iface0.name} inet manual
-            bond-master bond0
-
-        auto {iface1.name}
-        iface {iface1.name} inet manual
-            pre-up sleep 4
-            bond-master bond0
     """
     ).format(
         ipv4pub=builder.ipv4pub.first,
@@ -83,6 +83,15 @@ def test_ubuntu_2104_private_bonded_task_etc_network_interfaces(
         auto lo
         iface lo inet loopback
 
+        auto {iface0.name}
+        iface {iface0.name} inet manual
+            bond-master bond0
+
+        auto {iface1.name}
+        iface {iface1.name} inet manual
+            pre-up sleep 4
+            bond-master bond0
+
         auto bond0
         iface bond0 inet static
             address {ipv4priv.address}
@@ -97,15 +106,6 @@ def test_ubuntu_2104_private_bonded_task_etc_network_interfaces(
             bond-slaves {iface0.name} {iface1.name}
             dns-nameservers {dns1} {dns2}
 
-
-        auto {iface0.name}
-        iface {iface0.name} inet manual
-            bond-master bond0
-
-        auto {iface1.name}
-        iface {iface1.name} inet manual
-            pre-up sleep 4
-            bond-master bond0
     """
     ).format(
         ipv4priv=builder.ipv4priv.first,
@@ -129,6 +129,15 @@ def test_ubuntu_2104_public_bonded_task_etc_network_interfaces_with_custom_priva
         """\
         auto lo
         iface lo inet loopback
+
+        auto {iface0.name}
+        iface {iface0.name} inet manual
+            bond-master bond0
+
+        auto {iface1.name}
+        iface {iface1.name} inet manual
+            pre-up sleep 4
+            bond-master bond0
 
         auto bond0
         iface bond0 inet static
@@ -156,15 +165,6 @@ def test_ubuntu_2104_public_bonded_task_etc_network_interfaces_with_custom_priva
             post-down route del -net 192.168.5.0/24 gw {ipv4priv.gateway}
             post-up route add -net 172.16.0.0/12 gw {ipv4priv.gateway}
             post-down route del -net 172.16.0.0/12 gw {ipv4priv.gateway}
-
-        auto {iface0.name}
-        iface {iface0.name} inet manual
-            bond-master bond0
-
-        auto {iface1.name}
-        iface {iface1.name} inet manual
-            pre-up sleep 4
-            bond-master bond0
     """
     ).format(
         ipv4pub=builder.ipv4pub.first,
@@ -194,6 +194,15 @@ def test_ubuntu_2104_private_bonded_task_etc_network_interfaces_with_custom_priv
         auto lo
         iface lo inet loopback
 
+        auto {iface0.name}
+        iface {iface0.name} inet manual
+            bond-master bond0
+
+        auto {iface1.name}
+        iface {iface1.name} inet manual
+            pre-up sleep 4
+            bond-master bond0
+
         auto bond0
         iface bond0 inet static
             address {ipv4priv.address}
@@ -208,15 +217,6 @@ def test_ubuntu_2104_private_bonded_task_etc_network_interfaces_with_custom_priv
             bond-slaves {iface0.name} {iface1.name}
             dns-nameservers {dns1} {dns2}
 
-
-        auto {iface0.name}
-        iface {iface0.name} inet manual
-            bond-master bond0
-
-        auto {iface1.name}
-        iface {iface1.name} inet manual
-            pre-up sleep 4
-            bond-master bond0
     """
     ).format(
         ipv4priv=builder.ipv4priv.first,


### PR DESCRIPTION
It seems that placing the individual ifaces below the bond creates a 
situation where `systemctl restart networking` fails. Ordering with said 
interfacs above the bond results in success.