### PR TITLE
append instead of overwrite /etc/mdev.conf

### DIFF
--- a/packetnetworking/distros/alpine/test_alpine_3_bonded.py
+++ b/packetnetworking/distros/alpine/test_alpine_3_bonded.py
@@ -299,5 +299,5 @@ def test_alpine_3_persistent_interface_names(alpine_3_bonded_network):
         iface1=builder.network.interfaces[1],
     )
 
-    assert tasks["etc/mdev.conf"] == mdevconf_result
+    assert tasks["etc/mdev.conf"]["content"] == mdevconf_result
     assert tasks["etc/mactab"] == mactab_result

--- a/packetnetworking/distros/alpine/test_alpine_3_individual.py
+++ b/packetnetworking/distros/alpine/test_alpine_3_individual.py
@@ -238,7 +238,7 @@ def test_alpine_3_persistent_interface_names(alpine_3_individual_network):
         iface1=builder.network.interfaces[1],
     )
 
-    assert tasks["etc/mdev.conf"] == mdevconf_result
+    assert tasks["etc/mdev.conf"]["content"] == mdevconf_result
     assert tasks["etc/mactab"] == mactab_result
 
 

--- a/packetnetworking/utils.py
+++ b/packetnetworking/utils.py
@@ -232,7 +232,10 @@ def generate_persistent_names_mdev():
         {% endfor %}
     """
 
-    return {"etc/mdev.conf": mdevconf, "etc/mactab": mactab}
+    return {
+        "etc/mdev.conf": {"file_mode": "a", "template": mdevconf},
+        "etc/mactab": mactab,
+    }
 
 
 def resolvers(default):


### PR DESCRIPTION
/etc/mdev.conf has some default configuration. Previously we were
overwriting the file which was causing unexpected failures to properly
identify some devices.

This change should now append instead so all devices can be registered
properly.