### PR TITLE
include all interfaces in mactab

### DIFF
--- a/packetnetworking/builder.py
+++ b/packetnetworking/builder.py
@@ -75,6 +75,7 @@ class NetworkData(object):
         self.nw_metadata = None
         self.bonding = None
         self.interfaces = None
+        self.physical_interfaces = None
         self.bonds = None
         self.addresses = None
         self.resolvers = default_resolvers
@@ -105,6 +106,7 @@ class NetworkData(object):
             log.debug("Metadata Interfaces: {}".format(self.nw_metadata.interfaces))
             raise LookupError("No interfaces matched ones provided from metadata")
         self.interfaces = utils.RecursiveAttributes(matched_ifaces)
+        self.physical_interfaces = utils.RecursiveAttributes(physical_ifaces)
 
     def build_bonds(self):
         self.bonds = utils.RecursiveDictAttributes({})
@@ -125,6 +127,7 @@ class NetworkData(object):
         return {
             "bonding": self.bonding,
             "interfaces": self.interfaces,
+            "physical_interfaces": self.physical_interfaces,
             "bonds": self.bonds,
             "addresses": self.addresses,
             "resolvers": self.resolvers,

--- a/packetnetworking/distros/alpine/conftest.py
+++ b/packetnetworking/distros/alpine/conftest.py
@@ -38,8 +38,10 @@ def alpinebuilder(mockit, fake, metadata, patch_dict):
             {"name": "eth1", "mac": "00:0c:29:51:53:a2", "bond": "bond0"},
         ]
         phys_interfaces = [
-            {"name": "enp0", "mac": "00:0c:29:51:53:a1"},
-            {"name": "enp1", "mac": "00:0c:29:51:53:a2"},
+            {"name": "enp0", "mac": "00:0c:29:51:53:a4"},
+            {"name": "enp1", "mac": "00:0c:29:51:53:a3"},
+            {"name": "enp2", "mac": "00:0c:29:51:53:a1"},
+            {"name": "enp3", "mac": "00:0c:29:51:53:a2"},
         ]
         _metadata = {"network": {"interfaces": meta_interfaces}}
         if metadata:

--- a/packetnetworking/distros/alpine/test_alpine_3_bonded.py
+++ b/packetnetworking/distros/alpine/test_alpine_3_bonded.py
@@ -292,11 +292,15 @@ def test_alpine_3_persistent_interface_names(alpine_3_bonded_network):
 
         {iface0.meta_name} {iface0.mac}
         {iface1.meta_name} {iface1.mac}
+        eth2 {phys_iface0.mac}
+        eth3 {phys_iface1.mac}
     """
     ).format(
         header=utils.generated_header(),
         iface0=builder.network.interfaces[0],
         iface1=builder.network.interfaces[1],
+        phys_iface0=builder.network.physical_interfaces[0],
+        phys_iface1=builder.network.physical_interfaces[1],
     )
 
     assert tasks["etc/mdev.conf"] == mdevconf_result

--- a/packetnetworking/distros/alpine/test_alpine_3_individual.py
+++ b/packetnetworking/distros/alpine/test_alpine_3_individual.py
@@ -231,11 +231,15 @@ def test_alpine_3_persistent_interface_names(alpine_3_individual_network):
 
         {iface0.meta_name} {iface0.mac}
         {iface1.meta_name} {iface1.mac}
+        eth2 {phys_iface0.mac}
+        eth3 {phys_iface1.mac}
     """
     ).format(
         header=utils.generated_header(),
         iface0=builder.network.interfaces[0],
         iface1=builder.network.interfaces[1],
+        phys_iface0=builder.network.physical_interfaces[0],
+        phys_iface1=builder.network.physical_interfaces[1],
     )
 
     assert tasks["etc/mdev.conf"] == mdevconf_result

--- a/packetnetworking/utils.py
+++ b/packetnetworking/utils.py
@@ -230,6 +230,14 @@ def generate_persistent_names_mdev():
         {% for iface in interfaces %}
         {{ iface.meta_name }} {{ iface.mac }}
         {% endfor %}
+        {%- if net.physical_interfaces|length > interfaces|length %}
+        {%- set existing_macs = interfaces|map(attribute='mac') | list %}
+        {%- set ns = namespace(idx=interfaces|length) %}
+        {%- for iface in net.physical_interfaces if iface.mac not in existing_macs %}
+        eth{{ ns.idx }} {{ iface.mac }}
+        {% set ns.idx = ns.idx + 1 %}
+        {% endfor %}
+        {% endif %}
     """
 
     return {"etc/mdev.conf": mdevconf, "etc/mactab": mactab}


### PR DESCRIPTION
If more interfaces exist on the host than is registered in metadata,
and if the interfaces in metadata are not ordered first on the host.

```
Example:
  metadata:
    eth0: macA
    eth1: macB
  host:
    eth0: macC
    eth1: macD
    eth2: macA
    eth3: macB
```

The `nameif` tool which reads the mactab, will attempt to rename
eth2 to eth0 and eth3 to eth1 however eth0 and eth1 are already
taken by interfaces it doesn't know about and therefore cannot
apply the name fix.

This change resolves that by setting the interfaces defined in
metadata first and then defines all remaining interfaces as well
to ensure the metadata defined interfaces can be properly set.

Signed-off-by: Mike Mason <mason@packet.com>