### PR TITLE
Configure systemd-resolved for Ubuntu

### DIFF
--- a/packetnetworking/distros/debian/builder.py
+++ b/packetnetworking/distros/debian/builder.py
@@ -9,5 +9,11 @@ class DebianBuilder(DistroBuilder):
 
     def build_tasks(self):
         self.task_template("etc/hostname", "etc_hostname.j2")
-        self.task_template("etc/resolv.conf", "etc_resolv.conf.j2")
         self.task_template("etc/hosts", "etc_hosts.j2")
+        if self.metadata.operating_system.distro == "ubuntu":
+            # this should probably be a check if etc/resolv.conf symlinks to ../run/systemd/resolve/stub-resolv.conf instead
+            self.task_template(
+                "etc/systemd/resolved.conf", "etc_systemd_resolved.conf.j2"
+            )
+        else:
+            self.task_template("etc/resolv.conf", "etc_resolv.conf.j2")

--- a/packetnetworking/distros/debian/templates/etc_systemd_resolved.conf.j2
+++ b/packetnetworking/distros/debian/templates/etc_systemd_resolved.conf.j2
@@ -1,0 +1,2 @@
+[Resolve]
+DNS={{resolvers | join(" ")}}

--- a/packetnetworking/distros/debian/test_ubuntu_1804_bonded.py
+++ b/packetnetworking/distros/debian/test_ubuntu_1804_bonded.py
@@ -247,9 +247,9 @@ def test_ubuntu_1804_task_etc_modules(ubuntu_1804_bonded_network):
     assert tasks["etc/modules"]["content"] == result
 
 
-def test_ubuntu_1804_etc_resolvers_configured(ubuntu_1804_bonded_network, fake):
+def test_ubuntu_1804_etc_systemd_resolved_configured(ubuntu_1804_bonded_network, fake):
     """
-    Validates /etc/resolv.conf is configured correctly
+    Validates /etc/systemd/resolved.conf is configured correctly
     """
     builder = ubuntu_1804_bonded_network()
     resolver1 = fake.ipv4()
@@ -258,11 +258,12 @@ def test_ubuntu_1804_etc_resolvers_configured(ubuntu_1804_bonded_network, fake):
     tasks = builder.render()
     result = dedent(
         """\
-        nameserver {resolver1}
-        nameserver {resolver2}
+        [Resolve]
+        DNS={resolver1} {resolver2}
     """
     ).format(resolver1=resolver1, resolver2=resolver2)
-    assert tasks["etc/resolv.conf"] == result
+    assert tasks["etc/systemd/resolved.conf"] == result
+    assert "etc/resolv.conf" not in tasks
 
 
 def test_ubuntu_1804_etc_hostname_configured(ubuntu_1804_bonded_network):

--- a/packetnetworking/distros/debian/test_ubuntu_1804_individual.py
+++ b/packetnetworking/distros/debian/test_ubuntu_1804_individual.py
@@ -154,9 +154,11 @@ def test_ubuntu_1804_private_individual_task_etc_network_interfaces_with_custom_
     assert tasks["etc/network/interfaces"] == result
 
 
-def test_ubuntu_1804_etc_resolvers_configured(ubuntu_1804_individual_network, fake):
+def test_ubuntu_1804_etc_systemd_resolved_configured(
+    ubuntu_1804_individual_network, fake
+):
     """
-    Validates /etc/resolv.conf is configured correctly
+    Validates /etc/systemd/resolved.conf is configured correctly
     """
     builder = ubuntu_1804_individual_network()
     resolver1 = fake.ipv4()
@@ -165,11 +167,12 @@ def test_ubuntu_1804_etc_resolvers_configured(ubuntu_1804_individual_network, fa
     tasks = builder.render()
     result = dedent(
         """\
-        nameserver {resolver1}
-        nameserver {resolver2}
+        [Resolve]
+        DNS={resolver1} {resolver2}
     """
     ).format(resolver1=resolver1, resolver2=resolver2)
-    assert tasks["etc/resolv.conf"] == result
+    assert tasks["etc/systemd/resolved.conf"] == result
+    assert "etc/resolv.conf" not in tasks
 
 
 def test_ubuntu_1804_etc_hostname_configured(ubuntu_1804_individual_network):

--- a/packetnetworking/distros/debian/test_ubuntu_2004_bonded.py
+++ b/packetnetworking/distros/debian/test_ubuntu_2004_bonded.py
@@ -247,9 +247,9 @@ def test_ubuntu_2004_task_etc_modules(ubuntu_2004_bonded_network):
     assert tasks["etc/modules"]["content"] == result
 
 
-def test_ubuntu_2004_etc_resolvers_configured(ubuntu_2004_bonded_network, fake):
+def test_ubuntu_2004_etc_systemd_resolved_configured(ubuntu_2004_bonded_network, fake):
     """
-    Validates /etc/resolv.conf is configured correctly
+    Validates /etc/systemd/resolved.conf is configured correctly
     """
     builder = ubuntu_2004_bonded_network()
     resolver1 = fake.ipv4()
@@ -258,11 +258,12 @@ def test_ubuntu_2004_etc_resolvers_configured(ubuntu_2004_bonded_network, fake):
     tasks = builder.render()
     result = dedent(
         """\
-        nameserver {resolver1}
-        nameserver {resolver2}
+        [Resolve]
+        DNS={resolver1} {resolver2}
     """
     ).format(resolver1=resolver1, resolver2=resolver2)
-    assert tasks["etc/resolv.conf"] == result
+    assert tasks["etc/systemd/resolved.conf"] == result
+    assert "etc/resolv.conf" not in tasks
 
 
 def test_ubuntu_2004_etc_hostname_configured(ubuntu_2004_bonded_network):

--- a/packetnetworking/distros/debian/test_ubuntu_2004_individual.py
+++ b/packetnetworking/distros/debian/test_ubuntu_2004_individual.py
@@ -154,9 +154,11 @@ def test_ubuntu_2004_private_individual_task_etc_network_interfaces_with_custom_
     assert tasks["etc/network/interfaces"] == result
 
 
-def test_ubuntu_2004_etc_resolvers_configured(ubuntu_2004_individual_network, fake):
+def test_ubuntu_2004_etc_systemd_resolved_configured(
+    ubuntu_2004_individual_network, fake
+):
     """
-    Validates /etc/resolv.conf is configured correctly
+    Validates /etc/systemd/resolved.conf is configured correctly
     """
     builder = ubuntu_2004_individual_network()
     resolver1 = fake.ipv4()
@@ -165,11 +167,12 @@ def test_ubuntu_2004_etc_resolvers_configured(ubuntu_2004_individual_network, fa
     tasks = builder.render()
     result = dedent(
         """\
-        nameserver {resolver1}
-        nameserver {resolver2}
+        [Resolve]
+        DNS={resolver1} {resolver2}
     """
     ).format(resolver1=resolver1, resolver2=resolver2)
-    assert tasks["etc/resolv.conf"] == result
+    assert tasks["etc/systemd/resolved.conf"] == result
+    assert "etc/resolv.conf" not in tasks
 
 
 def test_ubuntu_2004_etc_hostname_configured(ubuntu_2004_individual_network):

--- a/packetnetworking/distros/debian/test_ubuntu_2204_bonded.py
+++ b/packetnetworking/distros/debian/test_ubuntu_2204_bonded.py
@@ -247,9 +247,9 @@ def test_ubuntu_2204_task_etc_modules(ubuntu_2204_bonded_network):
     assert tasks["etc/modules"]["content"] == result
 
 
-def test_ubuntu_2204_etc_resolvers_configured(ubuntu_2204_bonded_network, fake):
+def test_ubuntu_2204_etc_systemd_resolved_configured(ubuntu_2204_bonded_network, fake):
     """
-    Validates /etc/resolv.conf is configured correctly
+    Validates /etc/systemd/resolved.conf is configured correctly
     """
     builder = ubuntu_2204_bonded_network()
     resolver1 = fake.ipv4()
@@ -258,11 +258,12 @@ def test_ubuntu_2204_etc_resolvers_configured(ubuntu_2204_bonded_network, fake):
     tasks = builder.render()
     result = dedent(
         """\
-        nameserver {resolver1}
-        nameserver {resolver2}
+        [Resolve]
+        DNS={resolver1} {resolver2}
     """
     ).format(resolver1=resolver1, resolver2=resolver2)
-    assert tasks["etc/resolv.conf"] == result
+    assert tasks["etc/systemd/resolved.conf"] == result
+    assert "etc/resolv.conf" not in tasks
 
 
 def test_ubuntu_2204_etc_hostname_configured(ubuntu_2204_bonded_network):

--- a/packetnetworking/distros/debian/test_ubuntu_2204_individual.py
+++ b/packetnetworking/distros/debian/test_ubuntu_2204_individual.py
@@ -154,9 +154,11 @@ def test_ubuntu_2204_private_individual_task_etc_network_interfaces_with_custom_
     assert tasks["etc/network/interfaces"] == result
 
 
-def test_ubuntu_2204_etc_resolvers_configured(ubuntu_2204_individual_network, fake):
+def test_ubuntu_2204_etc_systemd_resolved_configured(
+    ubuntu_2204_individual_network, fake
+):
     """
-    Validates /etc/resolv.conf is configured correctly
+    Validates /etc/systemd/resolved.conf is configured correctly
     """
     builder = ubuntu_2204_individual_network()
     resolver1 = fake.ipv4()
@@ -165,11 +167,12 @@ def test_ubuntu_2204_etc_resolvers_configured(ubuntu_2204_individual_network, fa
     tasks = builder.render()
     result = dedent(
         """\
-        nameserver {resolver1}
-        nameserver {resolver2}
+        [Resolve]
+        DNS={resolver1} {resolver2}
     """
     ).format(resolver1=resolver1, resolver2=resolver2)
-    assert tasks["etc/resolv.conf"] == result
+    assert tasks["etc/systemd/resolved.conf"] == result
+    assert "etc/resolv.conf" not in tasks
 
 
 def test_ubuntu_2204_etc_hostname_configured(ubuntu_2204_individual_network):


### PR DESCRIPTION
Ubuntu is currently set up to use systemd-resolved with the DNS configuration
embedded in the images. This works fine for production but breaks the OSIE VM
tests. Its also not future proof and not where/how we want to be configuring
the network. So lets teach packet-networking about systemd-resolved.