### PR TITLE
Avoid need to preprocess redhat templates

### DIFF
--- a/packetnetworking/distros/distro_builder.py
+++ b/packetnetworking/distros/distro_builder.py
@@ -129,17 +129,17 @@ class DistroBuilder(utils.Tasks):
 
             file_mode = None
             mode = None
+            context = self.context()
             if isinstance(template, dict):
+                context.update(template.get("context") or {})
                 file_mode = template.get("file_mode")
                 mode = template.get("mode", None)
-                fmt = template.get("fmt")
                 template_path = template.get("template_path")
-                template = template.get("template")
-                if template_path is not None:
+                if template_path is None:
+                    template = template.get("template")
+                else:
                     with open(template_path, "r") as f:
                         template = f.read()
-                if fmt:
-                    template = template.format(**fmt)
 
             template = dedent(template)
             tmpl = Template(
@@ -157,10 +157,10 @@ class DistroBuilder(utils.Tasks):
                     rendered_tasks[path] = {
                         "file_mode": file_mode,
                         "mode": mode,
-                        "content": tmpl.render(self.context()),
+                        "content": tmpl.render(context),
                     }
                 else:
-                    rendered_tasks[path] = tmpl.render(self.context())
+                    rendered_tasks[path] = tmpl.render(context)
             except UndefinedError:
                 # having to use print as log.* isn't printing out the json
                 print(

--- a/packetnetworking/distros/redhat/bonded.py
+++ b/packetnetworking/distros/redhat/bonded.py
@@ -21,7 +21,7 @@ class RedhatBondedNetwork(NetworkBuilder):
             self.task_template(
                 "etc/sysconfig/network-scripts/ifcfg-{}".format(bond),
                 "bonded/etc_sysconfig_network-scripts_ifcfg-bondX.j2",
-                fmt={"bond": bond},
+                context={"bond": bond},
             )
 
             if self.ipv4pub and bond == "bond0":
@@ -30,12 +30,12 @@ class RedhatBondedNetwork(NetworkBuilder):
                 self.task_template(
                     "etc/sysconfig/network-scripts/ifcfg-{}:0".format(bond),
                     "bonded/etc_sysconfig_network-scripts_ifcfg-bondX_0.j2",
-                    fmt={"bond": bond},
+                    context={"bond": bond},
                 )
                 self.task_template(
                     "etc/sysconfig/network-scripts/route-{}".format(bond),
                     "bonded/etc_sysconfig_network-scripts_route-bondX.j2",
-                    fmt={"bond": bond},
+                    context={"bond": bond},
                 )
 
         for i, iface in enumerate(self.network.interfaces):
@@ -43,7 +43,7 @@ class RedhatBondedNetwork(NetworkBuilder):
             self.task_template(
                 "etc/sysconfig/network-scripts/ifcfg-" + name,
                 "bonded/etc_sysconfig_network-scripts_ifcfg-template.j2",
-                fmt={"iface": name, "i": i},
+                context={"iface": name, "i": i},
             )
 
         self.task_template(

--- a/packetnetworking/distros/redhat/templates/bonded/etc_sysconfig_network-scripts_ifcfg-bondX.j2
+++ b/packetnetworking/distros/redhat/templates/bonded/etc_sysconfig_network-scripts_ifcfg-bondX.j2
@@ -1,29 +1,29 @@
-DEVICE={bond}
-NAME={bond}
-{{% if "{bond}" == "bond0" %}}
-{{% if ip4pub %}}
-IPADDR={{{{ ip4pub.address }}}}
-NETMASK={{{{ ip4pub.netmask }}}}
-GATEWAY={{{{ ip4pub.gateway }}}}
-{{% else %}}
-IPADDR={{{{ ip4priv.address }}}}
-NETMASK={{{{ ip4priv.netmask }}}}
-GATEWAY={{{{ ip4priv.gateway }}}}
-{{% endif %}}
-{{% endif %}}
+DEVICE={{bond}}
+NAME={{bond}}
+{% if bond == "bond0" %}
+{% if ip4pub %}
+IPADDR={{ ip4pub.address }}
+NETMASK={{ ip4pub.netmask }}
+GATEWAY={{ ip4pub.gateway }}
+{% else %}
+IPADDR={{ ip4priv.address }}
+NETMASK={{ ip4priv.netmask }}
+GATEWAY={{ ip4priv.gateway }}
+{% endif %}
+{% endif %}
 BOOTPROTO=none
 ONBOOT=yes
 USERCTL=no
 TYPE=Bond
-BONDING_OPTS="mode={{{{ net.bonding.mode }}}} miimon=100 downdelay=200 updelay=200"
+BONDING_OPTS="mode={{ net.bonding.mode }} miimon=100 downdelay=200 updelay=200"
 
-{{% if "{bond}" == "bond0" %}}
-{{% if ip6pub %}}
+{% if bond == "bond0" %}
+{% if ip6pub %}
 IPV6INIT=yes
-IPV6ADDR={{{{ ip6pub.address }}}}/{{{{ ip6pub.cidr }}}}
-IPV6_DEFAULTGW={{{{ ip6pub.gateway }}}}
-{{% endif %}}
-{{% endif %}}
-{{% for dns in resolvers %}}
-DNS{{{{ loop.index }}}}={{{{ dns }}}}
-{{% endfor %}}
+IPV6ADDR={{ ip6pub.address }}/{{ ip6pub.cidr }}
+IPV6_DEFAULTGW={{ ip6pub.gateway }}
+{% endif %}
+{% endif %}
+{% for dns in resolvers %}
+DNS{{ loop.index }}={{ dns }}
+{% endfor %}

--- a/packetnetworking/distros/redhat/templates/bonded/etc_sysconfig_network-scripts_ifcfg-bondX_0.j2
+++ b/packetnetworking/distros/redhat/templates/bonded/etc_sysconfig_network-scripts_ifcfg-bondX_0.j2
@@ -1,11 +1,11 @@
-DEVICE={bond}:0
-NAME={bond}:0
-IPADDR={{{{ ip4priv.address }}}}
-NETMASK={{{{ ip4priv.netmask }}}}
-GATEWAY={{{{ ip4priv.gateway }}}}
+DEVICE={{bond}}:0
+NAME={{bond}}:0
+IPADDR={{ ip4priv.address }}
+NETMASK={{ ip4priv.netmask }}
+GATEWAY={{ ip4priv.gateway }}
 BOOTPROTO=none
 ONBOOT=yes
 USERCTL=no
-{{% for dns in resolvers %}}
-DNS{{{{ loop.index }}}}={{{{ dns }}}}
-{{% endfor %}}
+{% for dns in resolvers %}
+DNS{{ loop.index }}={{ dns }}
+{% endfor %}

--- a/packetnetworking/distros/redhat/templates/bonded/etc_sysconfig_network-scripts_ifcfg-template.j2
+++ b/packetnetworking/distros/redhat/templates/bonded/etc_sysconfig_network-scripts_ifcfg-template.j2
@@ -1,6 +1,6 @@
-DEVICE={iface}
+DEVICE={{iface}}
 ONBOOT=yes
-HWADDR={{{{ interfaces[{i}].mac }}}}
-MASTER={{{{ interfaces[{i}].bond }}}}
+HWADDR={{ interfaces[i].mac }}
+MASTER={{ interfaces[i].bond }}
 SLAVE=yes
 BOOTPROTO=none

--- a/packetnetworking/distros/redhat/templates/bonded/etc_sysconfig_network-scripts_route-bondX.j2
+++ b/packetnetworking/distros/redhat/templates/bonded/etc_sysconfig_network-scripts_route-bondX.j2
@@ -1,3 +1,3 @@
-{{% for subnet in private_subnets %}}
-{{{{ subnet }}}} via {{{{ ip4priv.gateway }}}} dev {bond}:0
-{{% endfor %}}
+{% for subnet in private_subnets %}
+{{ subnet }} via {{ ip4priv.gateway }} dev {{bond}}:0
+{% endfor %}

--- a/packetnetworking/utils.py
+++ b/packetnetworking/utils.py
@@ -139,18 +139,18 @@ class IPAddressList(WhereList):
 
 
 class Tasks(object):
-    def task(self, task, content, write_mode=None, mode=None, fmt=None):
+    def task(self, task, content, write_mode=None, mode=None, context=None):
         self.tasks[task] = {
             "file_mode": write_mode,
             "mode": mode,
             "template": content,
-            "fmt": fmt,
+            "context": context,
         }
         return self.tasks[task]
 
-    def task_template(self, task, path, write_mode=None, mode=None, fmt=None):
+    def task_template(self, task, path, write_mode=None, mode=None, context=None):
         path = os.path.join(package_dir, self.templates_base, path)
-        t = self.task(task, None, write_mode, mode, fmt)
+        t = self.task(task, None, write_mode, mode, context)
         t["template_path"] = path
         return t
 


### PR DESCRIPTION
This was quite ugly to see. Turns out we could just pass in the extra stuff via context and just use them in the template logic and it all works out. No need to escape `{` and `}` any more.