### PR TITLE
redhat: add rhel type for builder

### DIFF
--- a/packetnetworking/distros/redhat/builder.py
+++ b/packetnetworking/distros/redhat/builder.py
@@ -9,6 +9,7 @@ class RedhatBuilder(DistroBuilder):
         "centos",
         "redhatenterprise",
         "redhatenterpriseserver",
+        "rhel",
         "rocky",
     ]
     network_builders = [RedhatBondedNetwork, RedhatIndividualNetwork]


### PR DESCRIPTION
Trying to solve for this error- LookupError: No builders found for  distro 'rhel'