### PR TITLE
Debian fix multi-bonds

### DIFF
--- a/packetnetworking/distros/debian/conftest.py
+++ b/packetnetworking/distros/debian/conftest.py
@@ -39,6 +39,7 @@ def expected_file_etc_network_interfaces_dhcp_2():
         "1bond2nics",
         "1bond4nics",
         "2bonds2nics",
+        "2bonds2nics_unsorted",
     ],
     params=[
         [
@@ -57,13 +58,19 @@ def expected_file_etc_network_interfaces_dhcp_2():
             {"name": "eth2", "mac": "00:0c:29:51:53:a2", "bond": "bond1"},
             {"name": "eth3", "mac": "00:0c:29:51:53:a3", "bond": "bond1"},
         ],
+        [
+            {"name": "eth2", "mac": "00:0c:29:51:53:a2", "bond": "bond1"},
+            {"name": "eth3", "mac": "00:0c:29:51:53:a3", "bond": "bond1"},
+            {"name": "eth0", "mac": "00:0c:29:51:53:a0", "bond": "bond0"},
+            {"name": "eth1", "mac": "00:0c:29:51:53:a1", "bond": "bond0"},
+        ],
     ],
 )
 def debianbuilder(mockit, fake, metadata, patch_dict, request):
     gen_metadata = metadata
 
     def _builder(metadata=None, public=True, post_gen_metadata=None):
-        resolvers = ("1.2.3.4", "2.3.4.5")
+        resolvers = reversed([fake.ipv4(), fake.ipv4()])
         meta_interfaces = request.param
         phys_interfaces = [
             {"name": iface["name"].replace("eth", "enp"), "mac": iface["mac"]}

--- a/packetnetworking/distros/debian/templates/bonded/etc_network_interfaces.j2
+++ b/packetnetworking/distros/debian/templates/bonded/etc_network_interfaces.j2
@@ -16,7 +16,7 @@ iface {{ iface.name }} inet manual
 {% for bond in bonds %}
 
 auto {{ bond }}
-iface {{ bond }} inet static
+iface {{ bond }} inet {% if bond == "bond0" %}static{% else %}manual{% endif +%}
     {% if bond == "bond0" %}
     {% if ip4pub %}
     address {{ ip4pub.address }}

--- a/packetnetworking/distros/debian/templates/bonded/etc_network_interfaces.j2
+++ b/packetnetworking/distros/debian/templates/bonded/etc_network_interfaces.j2
@@ -2,7 +2,7 @@ auto lo
 iface lo inet loopback
 
 {% if osinfo.distro == 'ubuntu' %}
-{% for iface in interfaces %}
+{% for iface in interfaces | sort(attribute="name") %}
 
 auto {{ iface.name }}
 iface {{ iface.name }} inet manual
@@ -13,7 +13,7 @@ iface {{ iface.name }} inet manual
 {% endfor %}
 {% endif %}
 
-{% for bond in bonds %}
+{% for bond in bonds | sort %}
 
 auto {{ bond }}
 iface {{ bond }} inet {% if bond == "bond0" %}static{% else %}manual{% endif +%}
@@ -27,7 +27,7 @@ iface {{ bond }} inet {% if bond == "bond0" %}static{% else %}manual{% endif +%}
     netmask {{ ip4priv.netmask }}
     gateway {{ ip4priv.gateway }}
     {% endif %}
-    dns-nameservers {{ resolvers | join(" ") }}
+    dns-nameservers {{ resolvers | sort | join(" ") }}
 
     {% endif %}
     bond-downdelay 200
@@ -53,7 +53,7 @@ auto bond0:0
 iface bond0:0 inet static
     address {{ ip4priv.address }}
     netmask {{ ip4priv.netmask }}
-    {% for subnet in private_subnets %}
+    {% for subnet in private_subnets | sort %}
     post-up route add -net {{ subnet }} gw {{ ip4priv.gateway }}
     post-down route del -net {{ subnet }} gw {{ ip4priv.gateway }}
     {% endfor %}

--- a/packetnetworking/distros/debian/templates/individual/etc_network_interfaces.j2
+++ b/packetnetworking/distros/debian/templates/individual/etc_network_interfaces.j2
@@ -12,7 +12,7 @@ iface {{ iface0.name }} inet static
     netmask {{ ip4priv.netmask }}
     gateway {{ ip4priv.gateway }}
     {% endif %}
-    dns-nameservers {{ resolvers | join(" ") }}
+    dns-nameservers {{ resolvers | sort | join(" ") }}
 {% if ip6pub %}
 
 iface {{ iface0.name }} inet6 static
@@ -26,7 +26,7 @@ auto {{ iface0.name }}:0
 iface {{ iface0.name }}:0 inet static
     address {{ ip4priv.address }}
     netmask {{ ip4priv.netmask }}
-    {% for subnet in private_subnets %}
+    {% for subnet in private_subnets | sort %}
     post-up route add -net {{ subnet }} gw {{ ip4priv.gateway }}
     post-down route del -net {{ subnet }} gw {{ ip4priv.gateway }}
     {% endfor %}

--- a/packetnetworking/distros/debian/test_bonded.py
+++ b/packetnetworking/distros/debian/test_bonded.py
@@ -87,7 +87,7 @@ def test_public_bonded_task_etc_network_interfaces(
 
         partial = f"""
             auto {bond}
-            iface {bond} inet static
+            iface {bond} inet manual
                 bond-downdelay 200
                 bond-miimon 100
                 bond-mode {bonding_mode}
@@ -162,7 +162,7 @@ def test_private_bonded_task_etc_network_interfaces(
 
         partial = f"""
             auto {bond}
-            iface {bond} inet static
+            iface {bond} inet manual
                 bond-downdelay 200
                 bond-miimon 100
                 bond-mode {bonding_mode}
@@ -254,7 +254,7 @@ def test_public_bonded_task_etc_network_interfaces_with_custom_private_ip_space(
 
         partial = f"""
             auto {bond}
-            iface {bond} inet static
+            iface {bond} inet manual
                 bond-downdelay 200
                 bond-miimon 100
                 bond-mode {bonding_mode}
@@ -331,7 +331,7 @@ def test_private_bonded_task_etc_network_interfaces_with_custom_private_ip_space
 
         partial = f"""
             auto {bond}
-            iface {bond} inet static
+            iface {bond} inet manual
                 bond-downdelay 200
                 bond-miimon 100
                 bond-mode {bonding_mode}


### PR DESCRIPTION
Bonds 1+ need to be configured with method=manual instead of method=static since we do not have any _static_ addresses to configure them with. I've also gone through and sorted all the loop'd stuff so that the e-n-i contents isn't random depending on metadata json and python internals.