### PR TITLE
Avoid +%}

### DIFF
--- a/packetnetworking/distros/debian/templates/bonded/etc_network_interfaces.j2
+++ b/packetnetworking/distros/debian/templates/bonded/etc_network_interfaces.j2
@@ -16,7 +16,8 @@ iface {{ iface.name }} inet manual
 {% for bond in bonds | sort %}
 
 auto {{ bond }}
-iface {{ bond }} inet {% if bond == "bond0" %}static{% else %}manual{% endif +%}
+iface {{ bond }} inet {% if bond == "bond0" %}static{% else %}manual{% endif %}
+
     {% if bond == "bond0" %}
     {% if ip4pub %}
     address {{ ip4pub.address }}


### PR DESCRIPTION
The `+%}` to ignore trim_blocks that we use in debian bond method was not introduced until v3.0 which drops support for python3.5 that we still require :(.