### PR TITLE
Debian and Ubuntu fixed bond0 mac to 1st nic mac address in etc_netwo…

### DIFF
--- a/packetnetworking/distros/debian/templates/bonded/etc_network_interfaces.j2
+++ b/packetnetworking/distros/debian/templates/bonded/etc_network_interfaces.j2
@@ -26,6 +26,7 @@ iface {{ bond }} inet {% if bond == "bond0" %}static{% else %}manual{% endif %}
     netmask {{ ip4priv.netmask }}
     gateway {{ ip4priv.gateway }}
     {% endif %}
+    hwaddress {{ interfaces[0].mac }}
     dns-nameservers {{ resolvers | sort | join(" ") }}
 
     {% endif %}

--- a/packetnetworking/distros/debian/test_bonded.py
+++ b/packetnetworking/distros/debian/test_bonded.py
@@ -50,6 +50,7 @@ def test_public_bonded_task_etc_network_interfaces(
             address {ipv4pub.address}
             netmask {ipv4pub.netmask}
             gateway {ipv4pub.gateway}
+            hwaddress {builder.network.interfaces[0].mac}
             dns-nameservers {" ".join(sorted(builder.network.resolvers))}
 
             bond-downdelay 200
@@ -135,6 +136,7 @@ def test_private_bonded_task_etc_network_interfaces(
             address {ipv4priv.address}
             netmask {ipv4priv.netmask}
             gateway {ipv4priv.gateway}
+            hwaddress {builder.network.interfaces[0].mac}
             dns-nameservers {" ".join(sorted(builder.network.resolvers))}
 
             bond-downdelay 200
@@ -205,6 +207,7 @@ def test_public_bonded_task_etc_network_interfaces_with_custom_private_ip_space(
             address {ipv4pub.address}
             netmask {ipv4pub.netmask}
             gateway {ipv4pub.gateway}
+            hwaddress {builder.network.interfaces[0].mac}
             dns-nameservers {" ".join(sorted(builder.network.resolvers))}
 
             bond-downdelay 200
@@ -291,6 +294,7 @@ def test_private_bonded_task_etc_network_interfaces_with_custom_private_ip_space
             address {ipv4priv.address}
             netmask {ipv4priv.netmask}
             gateway {ipv4priv.gateway}
+            hwaddress {builder.network.interfaces[0].mac}
             dns-nameservers {" ".join(sorted(builder.network.resolvers))}
 
             bond-downdelay 200


### PR DESCRIPTION
…rk_interfaces.j2

Nokia switches have a fixed arp table, if the bond takes the second interface mac address it will not work at all. This will result in a failed deployment (lack of networking == no phone home == fail).