### PR TITLE
Debian10 network fix

### DIFF
--- a/packetnetworking/distros/debian/bonded.py
+++ b/packetnetworking/distros/debian/bonded.py
@@ -11,7 +11,19 @@ class DebianBondedNetwork(NetworkBuilder):
         self.build_tasks()
 
     def build_tasks(self):
-        self.task_template("etc/network/interfaces", "bonded/etc_network_interfaces.j2")
+        if (
+            self.metadata.operating_system.distro == "debian"
+            and self.metadata.operating_system.version == "10"
+        ):
+            # Debian10 is failing if we don't configure the net this way
+            self.task_template(
+                "etc/network/interfaces", "bonded/etc_network_interfaces_debian10.j2"
+            )
+        else:
+            self.task_template(
+                "etc/network/interfaces", "bonded/etc_network_interfaces.j2"
+            )
+
         self.task_template("etc/modules", "bonded/etc_modules.j2", write_mode="a")
         self.tasks.update(generate_persistent_names_udev())
         return self.tasks

--- a/packetnetworking/distros/debian/conftest.py
+++ b/packetnetworking/distros/debian/conftest.py
@@ -10,7 +10,7 @@ from .individual import DebianIndividualNetwork
 
 
 versions = {
-    "debian": ["10", "11", "12"],
+    "debian": ["11", "12"],
     "ubuntu": ["18.04", "20.04", "22.04"],
 }
 versions = [[distro, version] for distro in versions for version in versions[distro]]

--- a/packetnetworking/distros/debian/templates/bonded/etc_network_interfaces_debian10.j2
+++ b/packetnetworking/distros/debian/templates/bonded/etc_network_interfaces_debian10.j2
@@ -1,0 +1,62 @@
+auto lo
+iface lo inet loopback
+
+{% for bond in bonds | sort %}
+
+auto {{ bond }}
+iface {{ bond }} inet {% if bond == "bond0" %}static{% else %}manual{% endif %}
+
+    {% if bond == "bond0" %}
+    {% if ip4pub %}
+    address {{ ip4pub.address }}
+    netmask {{ ip4pub.netmask }}
+    gateway {{ ip4pub.gateway }}
+    {% else %}
+    address {{ ip4priv.address }}
+    netmask {{ ip4priv.netmask }}
+    gateway {{ ip4priv.gateway }}
+    {% endif %}
+    hwaddress {{ interfaces[0].mac }}
+    dns-nameservers {{ resolvers | sort | join(" ") }}
+
+    {% endif %}
+    bond-downdelay 200
+    bond-miimon 100
+    bond-mode {{ net.bonding.mode }}
+    bond-updelay 200
+    bond-xmit_hash_policy layer3+4
+    {% if net.bonding.mode == 4 %}
+    bond-lacp-rate 1
+    {% endif %}
+    bond-slaves {{ bonds[bond] | map(attribute='name') | sort | join(' ') }}
+{% if bond == "bond0" %}
+{% if ip6pub %}
+
+iface bond0 inet6 static
+    address {{ ip6pub.address }}
+    netmask {{ ip6pub.cidr }}
+    gateway {{ ip6pub.gateway }}
+{% endif %}
+{% if ip4pub %}
+
+auto bond0:0
+iface bond0:0 inet static
+    address {{ ip4priv.address }}
+    netmask {{ ip4priv.netmask }}
+    {% for subnet in private_subnets | sort %}
+    post-up route add -net {{ subnet }} gw {{ ip4priv.gateway }}
+    post-down route del -net {{ subnet }} gw {{ ip4priv.gateway }}
+    {% endfor %}
+{% endif %}
+{% endif %}
+{% endfor %}
+
+{% for iface in interfaces | sort(attribute="name") %}
+
+auto {{ iface.name }}
+iface {{ iface.name }} inet manual
+{% if iface.name != interfaces[0].name %}
+    pre-up sleep 4
+{% endif %}
+    bond-master bond0
+{% endfor %}


### PR DESCRIPTION
Debian10 leaves interfaces down if they are configured before bond0 in /etc/network/interfaces. 
It's a workaround, after 2 months we will remove this fix together with debian10