### PR TITLE
fix: use iface bond name, not bond0 always in deb bonded template

### DIFF
--- a/packetnetworking/distros/debian/templates/bonded/etc_network_interfaces.j2
+++ b/packetnetworking/distros/debian/templates/bonded/etc_network_interfaces.j2
@@ -8,7 +8,7 @@ iface {{ iface.name }} inet manual
 {% if iface.name != interfaces[0].name %}
     pre-up sleep 4
 {% endif %}
-    bond-master bond0
+    bond-master {{ iface.bond }}
 {% endfor %}
 
 {% for bond in bonds | sort %}

--- a/packetnetworking/distros/debian/test_bonded.py
+++ b/packetnetworking/distros/debian/test_bonded.py
@@ -35,13 +35,13 @@ def test_public_bonded_task_etc_network_interfaces(
                 auto {iface.name}
                 iface {iface.name} inet manual
                     pre-up sleep 4
-                    bond-master bond0
+                    bond-master {iface.bond}
                 """
         else:
             partial = f"""
                 auto {iface.name}
                 iface {iface.name} inet manual
-                    bond-master bond0
+                    bond-master {iface.bond}
                 """
         result += dedent(partial)
     partial = f"""
@@ -121,13 +121,13 @@ def test_private_bonded_task_etc_network_interfaces(
                 auto {iface.name}
                 iface {iface.name} inet manual
                     pre-up sleep 4
-                    bond-master bond0
+                    bond-master {iface.bond}
                 """
         else:
             partial = f"""
                 auto {iface.name}
                 iface {iface.name} inet manual
-                    bond-master bond0
+                    bond-master {iface.bond}
                 """
         result += dedent(partial)
     partial = f"""
@@ -192,13 +192,13 @@ def test_public_bonded_task_etc_network_interfaces_with_custom_private_ip_space(
                 auto {iface.name}
                 iface {iface.name} inet manual
                     pre-up sleep 4
-                    bond-master bond0
+                    bond-master {iface.bond}
                 """
         else:
             partial = f"""
                 auto {iface.name}
                 iface {iface.name} inet manual
-                    bond-master bond0
+                    bond-master {iface.bond}
                 """
         result += dedent(partial)
     partial = f"""
@@ -279,13 +279,13 @@ def test_private_bonded_task_etc_network_interfaces_with_custom_private_ip_space
                 auto {iface.name}
                 iface {iface.name} inet manual
                     pre-up sleep 4
-                    bond-master bond0
+                    bond-master {iface.bond}
                 """
         else:
             partial = f"""
                 auto {iface.name}
                 iface {iface.name} inet manual
-                    bond-master bond0
+                    bond-master {iface.bond}
                 """
         result += dedent(partial)
     partial = f"""


### PR DESCRIPTION
Networking was not working in Ubuntu 22.04 on `nvidia3.gh200.medium.arm64.v1` machines in SY5. I noticed that the template always assumes interfaces will be added to bond0, instead of the actual bond noted in the interface's context object provided to the template. 

This PR now ensures interfaces are added to their appropriate bond. 