### PR TITLE
change: alpine bonded template for multiple bonds

### DIFF
--- a/packetnetworking/distros/alpine/templates/bonded/etc_network_interfaces.j2
+++ b/packetnetworking/distros/alpine/templates/bonded/etc_network_interfaces.j2
@@ -1,8 +1,22 @@
 auto lo
 iface lo inet loopback
 
-auto bond0
-iface bond0 inet static
+{% for iface in interfaces | sort(attribute="meta_name") %}
+
+auto {{ iface.meta_name }}
+iface {{ iface.meta_name }} inet manual
+{% if iface.meta_name != interfaces[0].meta_name %}
+    pre-up sleep 4
+{% endif %}
+    bond-master {{ iface.bond }}
+{% endfor %}
+
+{% for bond in bonds | sort %}
+
+auto {{ bond }}
+iface {{ bond }} inet {% if bond == "bond0" %}static{% else %}manual{% endif %}
+
+    {% if bond == "bond0" %}
     {% if ip4pub %}
     address {{ ip4pub.address }}
     netmask {{ ip4pub.netmask }}
@@ -12,16 +26,20 @@ iface bond0 inet static
     netmask {{ ip4priv.netmask }}
     gateway {{ ip4priv.gateway }}
     {% endif %}
-    dns-nameservers {{ resolvers | join(" ") }}
+    hwaddress {{ interfaces[0].mac }}
+    dns-nameservers {{ resolvers | sort | join(" ") }}
 
-    use bond
-    requires {{ interfaces | map(attribute="meta_name") | join(" ") }}
-    bond-members {{ interfaces | map(attribute="meta_name") | join(" ") }}
-    bond-mode {{ net.bonding.mode }}
+    {% endif %}
     bond-downdelay 200
     bond-miimon 100
+    bond-mode {{ net.bonding.mode }}
     bond-updelay 200
     bond-xmit_hash_policy layer3+4
+    {% if net.bonding.mode == 4 %}
+    bond-lacp-rate 1
+    {% endif %}
+    bond-slaves {{ bonds[bond] | map(attribute='meta_name') | sort | join(' ') }}
+{% if bond == "bond0" %}
 {% if ip6pub %}
 
 iface bond0 inet6 static
@@ -35,8 +53,10 @@ auto bond0:0
 iface bond0:0 inet static
     address {{ ip4priv.address }}
     netmask {{ ip4priv.netmask }}
-    {% for subnet in private_subnets %}
+    {% for subnet in private_subnets | sort %}
     post-up route add -net {{ subnet }} gw {{ ip4priv.gateway }}
     post-down route del -net {{ subnet }} gw {{ ip4priv.gateway }}
     {% endfor %}
 {% endif %}
+{% endif %}
+{% endfor %}

--- a/packetnetworking/distros/alpine/test_alpine_3_bonded.py
+++ b/packetnetworking/distros/alpine/test_alpine_3_bonded.py
@@ -234,6 +234,98 @@ def test_alpine_3_private_bonded_task_etc_network_interfaces_with_custom_private
     assert tasks["etc/network/interfaces"] == result
 
 
+def test_alpine_3_public_bonded_task_etc_network_interfaces_with_two_bonds(
+    alpine_3_bonded_network,
+):
+    """
+    When there are two bonds in metadata, we should see two bonds in the
+    /etc/network/interfaces file.
+    """
+    new_meta_interfaces = [
+        {"name": "eth0", "mac": "00:0c:29:51:53:a1", "bond": "bond0"},
+        {"name": "eth1", "mac": "00:0c:29:51:53:a2", "bond": "bond0"},
+        {"name": "eth2", "mac": "00:0c:29:51:53:a4", "bond": "bond1"},
+        {"name": "eth3", "mac": "00:0c:29:51:53:a3", "bond": "bond1"},
+    ]
+    bond1 = {"network": {"interfaces": new_meta_interfaces}}
+    builder = alpine_3_bonded_network(public=True, metadata=bond1)
+    tasks = builder.render()
+
+    result = dedent(
+        """\
+        auto lo
+        iface lo inet loopback
+
+        auto eth0
+        iface eth0 inet manual
+            bond-master bond0
+
+        auto eth1
+        iface eth1 inet manual
+            pre-up sleep 4
+            bond-master bond0
+
+        auto eth2
+        iface eth2 inet manual
+            pre-up sleep 4
+            bond-master bond1
+
+        auto eth3
+        iface eth3 inet manual
+            pre-up sleep 4
+            bond-master bond1
+
+        auto bond0
+        iface bond0 inet static
+            address {ipv4pub.address}
+            netmask {ipv4pub.netmask}
+            gateway {ipv4pub.gateway}
+            hwaddress 00:0c:29:51:53:a1
+            dns-nameservers {dns1} {dns2}
+
+            bond-downdelay 200
+            bond-miimon 100
+            bond-mode {bonding_mode}
+            bond-updelay 200
+            bond-xmit_hash_policy layer3+4
+            bond-lacp-rate 1
+            bond-slaves eth0 eth1
+
+        iface bond0 inet6 static
+            address {ipv6pub.address}
+            netmask {ipv6pub.cidr}
+            gateway {ipv6pub.gateway}
+
+        auto bond0:0
+        iface bond0:0 inet static
+            address {ipv4priv.address}
+            netmask {ipv4priv.netmask}
+            post-up route add -net 10.0.0.0/8 gw {ipv4priv.gateway}
+            post-down route del -net 10.0.0.0/8 gw {ipv4priv.gateway}
+
+        auto bond1
+        iface bond1 inet manual
+            bond-downdelay 200
+            bond-miimon 100
+            bond-mode {bonding_mode}
+            bond-updelay 200
+            bond-xmit_hash_policy layer3+4
+            bond-lacp-rate 1
+            bond-slaves eth2 eth3
+    """
+    ).format(
+        ipv4pub=builder.ipv4pub.first,
+        ipv6pub=builder.ipv6pub.first,
+        ipv4priv=builder.ipv4priv.first,
+        iface0=builder.network.interfaces[0],
+        iface1=builder.network.interfaces[1],
+        bonding_mode=builder.network.bonding.mode,
+        dns1=builder.network.resolvers[0],
+        dns2=builder.network.resolvers[1],
+    )
+    assert tasks["etc/network/interfaces"] == result
+
+
 def test_alpine_3_task_etc_modules(alpine_3_bonded_network):
     """Validates /etc/modules for a public bond"""
     builder = alpine_3_bonded_network(public=True)

--- a/packetnetworking/distros/alpine/test_alpine_3_bonded.py
+++ b/packetnetworking/distros/alpine/test_alpine_3_bonded.py
@@ -21,21 +21,30 @@ def test_alpine_3_public_bonded_task_etc_network_interfaces(alpine_3_bonded_netw
         auto lo
         iface lo inet loopback
 
+        auto eth0
+        iface eth0 inet manual
+            bond-master bond0
+
+        auto eth1
+        iface eth1 inet manual
+            pre-up sleep 4
+            bond-master bond0
+
         auto bond0
         iface bond0 inet static
             address {ipv4pub.address}
             netmask {ipv4pub.netmask}
             gateway {ipv4pub.gateway}
+            hwaddress 00:0c:29:51:53:a1
             dns-nameservers {dns1} {dns2}
 
-            use bond
-            requires {iface0.meta_name} {iface1.meta_name}
-            bond-members {iface0.meta_name} {iface1.meta_name}
-            bond-mode {bonding_mode}
             bond-downdelay 200
             bond-miimon 100
+            bond-mode {bonding_mode}
             bond-updelay 200
             bond-xmit_hash_policy layer3+4
+            bond-lacp-rate 1
+            bond-slaves eth0 eth1
 
         iface bond0 inet6 static
             address {ipv6pub.address}
@@ -74,21 +83,30 @@ def test_alpine_3_private_bonded_task_etc_network_interfaces(alpine_3_bonded_net
         auto lo
         iface lo inet loopback
 
+        auto eth0
+        iface eth0 inet manual
+            bond-master bond0
+
+        auto eth1
+        iface eth1 inet manual
+            pre-up sleep 4
+            bond-master bond0
+
         auto bond0
         iface bond0 inet static
             address {ipv4priv.address}
             netmask {ipv4priv.netmask}
             gateway {ipv4priv.gateway}
+            hwaddress 00:0c:29:51:53:a1
             dns-nameservers {dns1} {dns2}
 
-            use bond
-            requires {iface0.meta_name} {iface1.meta_name}
-            bond-members {iface0.meta_name} {iface1.meta_name}
-            bond-mode {bonding_mode}
             bond-downdelay 200
             bond-miimon 100
+            bond-mode {bonding_mode}
             bond-updelay 200
             bond-xmit_hash_policy layer3+4
+            bond-lacp-rate 1
+            bond-slaves eth0 eth1
     """
     ).format(
         ipv4priv=builder.ipv4priv.first,
@@ -113,21 +131,30 @@ def test_alpine_3_public_bonded_task_etc_network_interfaces_with_custom_private_
         auto lo
         iface lo inet loopback
 
+        auto eth0
+        iface eth0 inet manual
+            bond-master bond0
+
+        auto eth1
+        iface eth1 inet manual
+            pre-up sleep 4
+            bond-master bond0
+
         auto bond0
         iface bond0 inet static
             address {ipv4pub.address}
             netmask {ipv4pub.netmask}
             gateway {ipv4pub.gateway}
+            hwaddress 00:0c:29:51:53:a1
             dns-nameservers {dns1} {dns2}
 
-            use bond
-            requires {iface0.meta_name} {iface1.meta_name}
-            bond-members {iface0.meta_name} {iface1.meta_name}
-            bond-mode {bonding_mode}
             bond-downdelay 200
             bond-miimon 100
+            bond-mode {bonding_mode}
             bond-updelay 200
             bond-xmit_hash_policy layer3+4
+            bond-lacp-rate 1
+            bond-slaves eth0 eth1
 
         iface bond0 inet6 static
             address {ipv6pub.address}
@@ -138,10 +165,10 @@ def test_alpine_3_public_bonded_task_etc_network_interfaces_with_custom_private_
         iface bond0:0 inet static
             address {ipv4priv.address}
             netmask {ipv4priv.netmask}
-            post-up route add -net 192.168.5.0/24 gw {ipv4priv.gateway}
-            post-down route del -net 192.168.5.0/24 gw {ipv4priv.gateway}
             post-up route add -net 172.16.0.0/12 gw {ipv4priv.gateway}
             post-down route del -net 172.16.0.0/12 gw {ipv4priv.gateway}
+            post-up route add -net 192.168.5.0/24 gw {ipv4priv.gateway}
+            post-down route del -net 192.168.5.0/24 gw {ipv4priv.gateway}
     """
     ).format(
         ipv4pub=builder.ipv4pub.first,
@@ -171,21 +198,30 @@ def test_alpine_3_private_bonded_task_etc_network_interfaces_with_custom_private
         auto lo
         iface lo inet loopback
 
+        auto eth0
+        iface eth0 inet manual
+            bond-master bond0
+
+        auto eth1
+        iface eth1 inet manual
+            pre-up sleep 4
+            bond-master bond0
+
         auto bond0
         iface bond0 inet static
             address {ipv4priv.address}
             netmask {ipv4priv.netmask}
             gateway {ipv4priv.gateway}
+            hwaddress 00:0c:29:51:53:a1
             dns-nameservers {dns1} {dns2}
 
-            use bond
-            requires {iface0.meta_name} {iface1.meta_name}
-            bond-members {iface0.meta_name} {iface1.meta_name}
-            bond-mode {bonding_mode}
             bond-downdelay 200
             bond-miimon 100
+            bond-mode {bonding_mode}
             bond-updelay 200
             bond-xmit_hash_policy layer3+4
+            bond-lacp-rate 1
+            bond-slaves eth0 eth1
     """
     ).format(
         ipv4priv=builder.ipv4priv.first,


### PR DESCRIPTION
# Relevant JIRA

https://equinixjira.atlassian.net/browse/BMS-898

## What does this PR do?

Updates the Alpine bonded template to account for multiple bonds in an instance.

## Why is this necessary?

Currently, provisioning `alpine_3` on some plans fails due to networking not coming up on the host on first boot. This is due to the current template rendering all interfaces in the same bond, even if metadata for the instance declares multiple bonds.

## (How) Has This Been Tested?

In CI, and [OSIE](https://buildkite.com/equinix/osie/builds/5778)