### PR TITLE
fix: AlpineBonded ENI template bad bond options

### DIFF
--- a/packetnetworking/distros/alpine/templates/bonded/etc_network_interfaces.j2
+++ b/packetnetworking/distros/alpine/templates/bonded/etc_network_interfaces.j2
@@ -8,7 +8,6 @@ iface {{ iface.meta_name }} inet manual
 {% if iface.meta_name != interfaces[0].meta_name %}
     pre-up sleep 4
 {% endif %}
-    bond-master {{ iface.bond }}
 {% endfor %}
 
 {% for bond in bonds | sort %}

--- a/packetnetworking/distros/alpine/test_alpine_3_bonded.py
+++ b/packetnetworking/distros/alpine/test_alpine_3_bonded.py
@@ -23,12 +23,10 @@ def test_alpine_3_public_bonded_task_etc_network_interfaces(alpine_3_bonded_netw
 
         auto eth0
         iface eth0 inet manual
-            bond-master bond0
 
         auto eth1
         iface eth1 inet manual
             pre-up sleep 4
-            bond-master bond0
 
         auto bond0
         iface bond0 inet static
@@ -85,12 +83,10 @@ def test_alpine_3_private_bonded_task_etc_network_interfaces(alpine_3_bonded_net
 
         auto eth0
         iface eth0 inet manual
-            bond-master bond0
 
         auto eth1
         iface eth1 inet manual
             pre-up sleep 4
-            bond-master bond0
 
         auto bond0
         iface bond0 inet static
@@ -133,12 +129,10 @@ def test_alpine_3_public_bonded_task_etc_network_interfaces_with_custom_private_
 
         auto eth0
         iface eth0 inet manual
-            bond-master bond0
 
         auto eth1
         iface eth1 inet manual
             pre-up sleep 4
-            bond-master bond0
 
         auto bond0
         iface bond0 inet static
@@ -200,12 +194,10 @@ def test_alpine_3_private_bonded_task_etc_network_interfaces_with_custom_private
 
         auto eth0
         iface eth0 inet manual
-            bond-master bond0
 
         auto eth1
         iface eth1 inet manual
             pre-up sleep 4
-            bond-master bond0
 
         auto bond0
         iface bond0 inet static
@@ -258,22 +250,18 @@ def test_alpine_3_public_bonded_task_etc_network_interfaces_with_two_bonds(
 
         auto eth0
         iface eth0 inet manual
-            bond-master bond0
 
         auto eth1
         iface eth1 inet manual
             pre-up sleep 4
-            bond-master bond0
 
         auto eth2
         iface eth2 inet manual
             pre-up sleep 4
-            bond-master bond1
 
         auto eth3
         iface eth3 inet manual
             pre-up sleep 4
-            bond-master bond1
 
         auto bond0
         iface bond0 inet static


### PR DESCRIPTION
# Relevant JIRA

https://equinixjira.atlassian.net/browse/BMS-898

## What does this PR do?

Updates the Alpine bonded template to remove the `bond-master` option from the `ethX` stanzas.

## Why is this necessary?

When both bond-master and bond-slaves are present, bond-slaves is ignored. This leads to the bond-* options associated with the bond-slaves stanza to be ignored as well. We observed that this led to provisioned Alpine linux machines to have balance-rr (mode 3) bonding mode instead of 802.3ad (mode 4) bonding mode. This caused packets to be sent out-of-order, leading to TCP/IP congestion control due to packet loss.

Removing the bond-master option from the ethX stanzas fixes this issue and ensures the bonding driver uses our declared bond-* options in the bond stanzas.

## (How) Has This Been Tested?

In CI, by hand with `a3.large.x86` and `n3.xlarge.x86` provisions, and [OSIE](https://buildkite.com/equinix/osie/builds/5810)